### PR TITLE
include a poly identity function to the TraceT implicit scope - usefu…

### DIFF
--- a/core/src/main/scala/com/ccadllc/cedi/dtrace/TraceT.scala
+++ b/core/src/main/scala/com/ccadllc/cedi/dtrace/TraceT.scala
@@ -309,6 +309,11 @@ private[dtrace] sealed trait TraceTPolyFunctions {
     new (F ~> TraceT[F, ?]) {
       def apply[A](fa: F[A]): TraceT[F, A] = TraceT.toTraceT(fa)
     }
+
+  implicit def traceTIdentity[F[_]]: TraceT[F, ?] ~> TraceT[F, ?] =
+    new (TraceT[F, ?] ~> TraceT[F, ?]) {
+      def apply[A](tta: TraceT[F, A]): TraceT[F, A] = tta
+    }
 }
 
 private[dtrace] sealed trait TraceTInstancesLowPriority {


### PR DESCRIPTION
…l for building enhanced functionality on top of TraceT (such as an EitherTBuilder to make working with the EitherT monad transformer with TraceT and  derived data types). 