### PR TITLE
Fix X-MoneyTrace header parsing

### DIFF
--- a/core/src/main/scala/com/ccadllc/cedi/dtrace/SpanId.scala
+++ b/core/src/main/scala/com/ccadllc/cedi/dtrace/SpanId.scala
@@ -72,7 +72,7 @@ object SpanId {
   final val SpanIdHeader: String = "span-id"
 
   /* Used to validate / parse `Money` compliant HTTP header into a [[SpanId]] instance. */
-  final val HeaderRegex: Regex = s"$TraceIdHeader=([0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-fA-F]{12});$ParentIdHeader=([\\-0-9]+);$SpanIdHeader=([\\-0-9]+)".r
+  final val HeaderRegex: Regex = s"$TraceIdHeader=([0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-fA-F]{12});$ParentIdHeader=([\\-0-9]+);$SpanIdHeader=([\\-0-9]+)".r
 
   /**
    * Creates a root [[SpanId]] from stratch in an effectful program `F[A]`.

--- a/core/src/test/scala/com/ccadllc/cedi/dtrace/HeaderTest.scala
+++ b/core/src/test/scala/com/ccadllc/cedi/dtrace/HeaderTest.scala
@@ -1,0 +1,14 @@
+package com.ccadllc.cedi.dtrace
+
+import org.scalatest.{ Matchers, WordSpec }
+
+class HeaderTest extends WordSpec with Matchers with TestData {
+  "the X-MoneyTrace format header" should {
+    "be parsed correctly as a SpanId" in {
+      val headerParseResult =
+        SpanId.fromHeader(SpanId.HeaderName, xMoneyTraceHeader).right.toOption
+
+      headerParseResult.map(_.toHeader) should contain(xMoneyTraceHeader)
+    }
+  }
+}

--- a/core/src/test/scala/com/ccadllc/cedi/dtrace/TestData.scala
+++ b/core/src/test/scala/com/ccadllc/cedi/dtrace/TestData.scala
@@ -39,6 +39,13 @@ trait TestData {
   )
   // format: ON
 
+  protected val xMoneyTraceHeader: String = {
+    val traceId = UUID.randomUUID.toString
+    val parentId = scala.util.Random.nextLong()
+    val spanId = scala.util.Random.nextLong()
+    s"trace-id=$traceId;parent-id=$parentId;span-id=$spanId"
+  }
+
   protected val quarterlySalesCalculationSpanId: SpanId = SpanId(UUID.randomUUID, 20L, 30L)
   protected val quarterlySalesUnitsNoteValue: Note.LongValue = Note.LongValue(450000L)
   protected val quarterlySalesUnitsNote: Note = Note(Note.Name("quarterlySalesUnits"), Some(quarterlySalesUnitsNoteValue))


### PR DESCRIPTION
The regex for parsing the X-MoneyTrace header captured an extra group, which is incompatible with the later pattern match (which only expects three captured values).

This change makes the group non-capturing, and adds a small test for parsing one of these headers.

(note: I haven't signed your CLA yet)