### PR TITLE
backport stack safety fix from the newer 1.5.0 cedi-dtrace (which use…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 lazy val circeVersion = "0.9.3"
 
+lazy val catsEffectVersion = "0.10"
+
 lazy val http4sVersion = "0.18.11"
 
 lazy val logbackVersion = "1.2.3"
@@ -13,7 +15,7 @@ lazy val commonSettings = Seq(
     Contributor("mpilquist", "Michael Pilquist")
   ),
   libraryDependencies ++= Seq(
-    "org.typelevel" %% "cats-effect" % "0.10",
+    "org.typelevel" %% "cats-effect" % catsEffectVersion,
     "org.scalatest" %% "scalatest" % "3.0.4" % "test",
     "org.scalacheck" %% "scalacheck" % "1.13.5" % "test"
   ),
@@ -26,6 +28,7 @@ lazy val core = project.in(file("core")).enablePlugins(SbtOsgi).
   settings(commonSettings).
   settings(
     name := "dtrace-core",
+    libraryDependencies += "org.typelevel" %% "cats-effect-laws" % catsEffectVersion % "test",
     buildOsgiBundle("com.ccadllc.cedi.dtrace")
   )
 
@@ -88,5 +91,8 @@ lazy val http4s = project.in(file("http4s")).enablePlugins(SbtOsgi).
   ).dependsOn(core % "compile->compile;test->test", money % "compile->test", xb3 % "compile->test")
 
 lazy val readme = project.in(file("readme")).settings(commonSettings).settings(noPublish).enablePlugins(TutPlugin).settings(
-  tutTargetDirectory := baseDirectory.value / ".."
-).dependsOn(core, logging)
+  tutTargetDirectory := baseDirectory.value / "..",
+  libraryDependencies ++= Seq(
+    "org.http4s" %% "http4s-dsl" % http4sVersion,
+    "org.http4s" %% "http4s-circe" % http4sVersion)
+).dependsOn(core, logging, money, xb3, http4s)

--- a/core/src/test/scala/com/ccadllc/cedi/dtrace/TypeclassLawTests.scala
+++ b/core/src/test/scala/com/ccadllc/cedi/dtrace/TypeclassLawTests.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Combined Conditional Access Development, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ccadllc.cedi.dtrace
+
+import cats._
+
+import cats.effect._
+import cats.effect.laws.discipline._
+import cats.effect.laws.discipline.arbitrary._
+import cats.effect.laws.util._
+
+import cats.implicits._
+
+import cats.kernel.Eq
+
+import cats.laws.discipline.arbitrary._
+
+import java.io.{ ByteArrayOutputStream, PrintStream }
+import java.nio.charset.Charset
+
+import org.scalacheck._
+import org.scalatest.prop.Checkers
+import org.scalatest.{ FunSuite, Matchers }
+
+import org.typelevel.discipline.Laws
+import org.typelevel.discipline.scalatest.Discipline
+
+import scala.util.control.NonFatal
+
+class TypeclassLawTests extends FunSuite with Matchers with Checkers with Discipline with TestInstances with TestData {
+
+  private implicit def eqTraceIO[A](implicit A: Eq[A], testC: TestContext): Eq[TraceIO[A]] =
+    new Eq[TraceIO[A]] {
+      def eqv(x: TraceIO[A], y: TraceIO[A]): Boolean =
+        eqIO[A].eqv(x.tie(tc), y.tie(tc))
+    }
+
+  private implicit def catsConcurrentEffectLawsArbitraryForTraceIO[A: Arbitrary: Cogen]: Arbitrary[TraceIO[A]] =
+    Arbitrary(catsEffectLawsArbitraryForIO[A].arbitrary map TraceIO.toTraceIO)
+
+  private implicit val tc: TraceContext[IO] = TraceContext(
+    Span.root[IO](Span.Name("calculate-quarterly-sales")).unsafeRunSync,
+    TraceSystem(testSystemMetadata, new TestEmitter[IO])
+  )
+
+  checkAllAsync("TraceIO", implicit ec => ConcurrentEffectTests[TraceIO].concurrentEffect[Int, Int, Int])
+
+  private def checkAllAsync(name: String, f: TestContext => Laws#RuleSet): Unit = {
+    val context = TestContext()
+    val ruleSet = f(context)
+    for ((id, prop) <- ruleSet.all.properties)
+      test(s"$name.$id") { silenceSystemErr(check(prop)) }
+  }
+
+  private def silenceSystemErr[A](thunk: => A): A = synchronized {
+    val oldErr = System.err
+    val outStream = new ByteArrayOutputStream()
+    val silentErr = new PrintStream(outStream)
+    System.setErr(silentErr)
+    try {
+      val r = thunk
+      System.setErr(oldErr)
+      r
+    } catch {
+      case NonFatal(e) =>
+        System.setErr(oldErr)
+        val out = outStream.toString(Charset.defaultCharset.displayName)
+        if (out.nonEmpty) oldErr.println(out)
+        silentErr.close()
+        throw e
+    }
+  }
+}

--- a/core/src/test/scala/com/ccadllc/cedi/dtrace/TypeclassLawTests.scala
+++ b/core/src/test/scala/com/ccadllc/cedi/dtrace/TypeclassLawTests.scala
@@ -56,11 +56,11 @@ class TypeclassLawTests extends FunSuite with Matchers with Checkers with Discip
     TraceSystem(testSystemMetadata, new TestEmitter[IO])
   )
 
-  checkAllAsync("TraceIO", implicit ec => ConcurrentEffectTests[TraceIO].concurrentEffect[Int, Int, Int])
+  checkAllAsync("TraceIO", implicit testC => ConcurrentEffectTests[TraceIO].concurrentEffect[Int, Int, Int])
 
   private def checkAllAsync(name: String, f: TestContext => Laws#RuleSet): Unit = {
-    val context = TestContext()
-    val ruleSet = f(context)
+    val testC = TestContext()
+    val ruleSet = f(testC)
     for ((id, prop) <- ruleSet.all.properties)
       test(s"$name.$id") { silenceSystemErr(check(prop)) }
   }


### PR DESCRIPTION
…s cats-effect 1.0) to the 1.4.x series - also include laws tests which originally caught the issue.