### PR TITLE
Rev dependencies to cats-effect 1.0, circe 0.10, cats.1.4, http4s 0.1…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,27 @@
-
+1.5.0
+=====
+ - Updated typeclasses to use cats-effect 1.0, which includes a number
+   of changes, including the `Bracket` typeclass for handling finalization
+   and resource cleanup. This typeclass and the `TraceT.bracket` and
+   `TraceT.bracketCase` convenience methods take the place of the
+   `cedi-dtrace` 1.x `bestEffortOnFinish` function. Also added `ContextShift`
+   typeclass to handle shifting to a new thread pool with `shift` and to
+   temporarily evaluate an effect on a thread pool and then shift back to the
+   current one via `evalOn` (the use case for the latter is primarily to evalute
+   a blocking effect on a dedicated thread pool to avoid possible deadlocks).
+ - Removed requirement for a `TraceContext[F]` in implicit scope for
+   `Concurrent` typeclass.
+ - Fixed stack safety issues with TraceT instances. Previously, it was possible
+   to get stack overflow exceptions with deeply nested `flatMap`, `map` and
+   `attempt` invocations.
+ - Added law testing of typeclass instances.
+1.4.0
+=====
+ - Guard marker creation if debug is disabled in LogstashLogbackEmitter.
 1.3.0
 =====
- - Implement ConcurrentEffect and Timer typeclass
- - Fixed issue with Effect typeclass runAsync function implementation
+ - Implement `ConcurrentEffect` and `Timer` typeclass
+ - Fixed issue with `Effect` typeclass `runAsync` function implementation
    causing loss of trace context.
  - Added money, xb3, and http4s modules, with support for Money,
  - and X-B3 headers and generation and extraction of trace information to/from

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Quick links:
 - [Examples of use](#usage)
 - [Configuration](#config)
 - [How to get latest version](#getit)
-- API Docs [Core](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-core_2.12/1.3.0/dtrace-core_2.12-1.3.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/index.html) [Logging](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-logging_2.12/1.3.0/dtrace-logging_2.12-1.3.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/logging/index.html)
+- API Docs [Core](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-core_2.12/1.5.0/dtrace-core_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/index.html) [Logging](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-logging_2.12/1.5.0/dtrace-logging_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/logging/index.html)
 
 
 ### <a id="about"></a>About the library
@@ -40,7 +40,7 @@ import org.http4s._
 import org.http4s.dsl.io._
 
 import com.ccadllc.cedi.dtrace._
-import com.ccadllc.cedi.dtrace.interop.htt4s._
+import com.ccadllc.cedi.dtrace.interop.http4s._
 import com.ccadllc.cedi.dtrace.logging.LogEmitter
 
 import TraceSystem._
@@ -196,7 +196,7 @@ Cedi Distributed Trace supports Scala 2.11 and 2.12. This distribution is publis
 This is the core functionality, recording trace and span information over effectful programs, passing these recorded events to registred emitters for disposition.
 
 ```scala
-libraryDependencies += "com.ccadllc.cedi" %% "dtrace-core" % "1.3.0-SNAPSHOT"
+libraryDependencies += "com.ccadllc.cedi" %% "dtrace-core" % "1.5.0"
 ```
 
 #### dtrace-logging
@@ -204,7 +204,7 @@ libraryDependencies += "com.ccadllc.cedi" %% "dtrace-core" % "1.3.0-SNAPSHOT"
 This component provides emitters for logging the trace spans in text and/or JSON format using the `sf4j` logging framework.  It uses the `circe` library for formatting the trace span information as JSON.
 
 ```scala
-libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logging" % "1.3.0-SNAPSHOT"
+libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logging" % "1.5.0"
 ```
 
 #### dtrace-logstash
@@ -212,7 +212,7 @@ libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logging" % "1.3.0-SNAPSHOT
 This component provides emitters for logging in logstash-compliant format.
 
 ```scala
-libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logstash" % "1.3.0-SNAPSHOT"
+libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logstash" % "1.5.0"
 ```
 
 #### dtrace-money interoperability
@@ -220,7 +220,7 @@ libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logstash" % "1.3.0-SNAPSHO
 This component provides an instance of the core HeaderCodec in order to encode and decode Money-compliant HTTP headers.
 
 ```scala
-libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-money" % "1.3.0-SNAPSHOT"
+libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-money" % "1.5.0"
 ```
 
 #### dtrace-xb3 interoperability
@@ -228,7 +228,7 @@ libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-money" % "1.3.0-SNAPSHOT"
 This component provides an insance of the core HeaderCodec in order to encode and decode X-B3/Zipkin-compliant HTTP headers.
 
 ```scala
-libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-xb3" % "1.3.0-SNAPSHOT"
+libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-xb3" % "1.5.0"
 ```
 
 #### dtrace-http4s interoperability
@@ -236,7 +236,7 @@ libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-xb3" % "1.3.0-SNAPSHOT"
 This component provides convenience functions to ingest trace-related HTTP headers (such as Money or X-B3) in an http4s server-side service and to propagate trace-related HTTP headers within an http4s client-side request to a remote entity.  This module is used in combination with either or both the dtrace-xb3 and dtrace-money modules.  If you have another protocol you wish to use instead, it will likewise interoperate with any implementation of the core HeaderCodec trait in implicit scope.
 
 ```scala
-libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-http4s" % "1.3.0-SNAPSHOT"
+libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-http4s" % "1.5.0"
 ```
 
 ## Copyright and License

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Quick links:
 - [Examples of use](#usage)
 - [Configuration](#config)
 - [How to get latest version](#getit)
-- API Docs [Core](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-core_2.12/1.5.0/dtrace-core_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/index.html) [Logging](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-logging_2.12/1.5.0/dtrace-logging_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/logging/index.html)
+- API Docs [Core](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-core_2.12/1.5.0/dtrace-core_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/index.html) [Logging](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-logging_2.12/1.5.0/dtrace-logging_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/logging/index.html) [Logstash](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-logstash_2.12/1.5.0/dtrace-logstash_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/logstash/index.html) [Money](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-money_2.12/1.5.0/dtrace-money_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/money/index.html) [Http4s](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-http4s_2.12/1.5.0/dtrace-http4s_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/http4s/index.html) [XB3](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-xb3_2.12/1.5.0/dtrace-xb3_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/xb3/index.html)
 
 
 ### <a id="about"></a>About the library

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,10 @@
-lazy val circeVersion = "0.9.3"
+lazy val catsEffectVersion = "1.0.0"
 
-lazy val http4sVersion = "0.18.11"
+lazy val catsCoreVersion = "1.4.0"
+
+lazy val circeVersion = "0.10.0"
+
+lazy val http4sVersion = "0.19.0-M2"
 
 lazy val logbackVersion = "1.2.3"
 
@@ -13,11 +17,19 @@ lazy val commonSettings = Seq(
     Contributor("mpilquist", "Michael Pilquist")
   ),
   libraryDependencies ++= Seq(
-    "org.typelevel" %% "cats-effect" % "0.10",
-    "org.scalatest" %% "scalatest" % "3.0.4" % "test",
-    "org.scalacheck" %% "scalacheck" % "1.13.5" % "test"
-  ),
-  addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3")
+    "org.typelevel" %% "cats-core" % catsCoreVersion,
+    "org.typelevel" %% "cats-effect" % catsEffectVersion
+  ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, v)) if v >= 13 => Seq(
+      "org.scalatest" %% "scalatest" % "3.0.6-SNAP2" % "test",
+      "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
+    )
+    case _ => Seq(
+      "org.scalatest" %% "scalatest" % "3.0.5" % "test",
+      "org.scalacheck" %% "scalacheck" % "1.13.5" % "test"
+    )
+  }),
+  addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7")
 )
 
 lazy val root = project.in(file(".")).aggregate(core, logging, logstash, xb3, money, http4s).settings(commonSettings).settings(noPublish)
@@ -26,6 +38,7 @@ lazy val core = project.in(file("core")).enablePlugins(SbtOsgi).
   settings(commonSettings).
   settings(
     name := "dtrace-core",
+    libraryDependencies += "org.typelevel" %% "cats-effect-laws" % catsEffectVersion % "test",
     buildOsgiBundle("com.ccadllc.cedi.dtrace")
   )
 
@@ -37,7 +50,6 @@ lazy val logging = project.in(file("logging")).enablePlugins(SbtOsgi).
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
-      "io.circe" %% "circe-java8" % circeVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "ch.qos.logback" % "logback-core" % logbackVersion % "test",
       "ch.qos.logback" % "logback-classic" % logbackVersion % "test",
@@ -64,7 +76,7 @@ lazy val xb3 = project.in(file("xb3")).enablePlugins(SbtOsgi).
   settings(commonSettings).
   settings(
     name := "dtrace-xb3",
-    libraryDependencies += "org.scodec" %% "scodec-bits" % "1.1.5",
+    libraryDependencies += "org.scodec" %% "scodec-bits" % "1.1.6",
     buildOsgiBundle("com.ccadllc.cedi.dtrace.interop.xb3")
   ).dependsOn(core % "compile->compile;test->test")
 
@@ -80,16 +92,27 @@ lazy val http4s = project.in(file("http4s")).enablePlugins(SbtOsgi).
   settings(
     name := "dtrace-http4s",
     parallelExecution in Test := false,
-    libraryDependencies ++= Seq(
-      "org.http4s" %% "http4s-core" % http4sVersion,
-      "org.http4s" %% "http4s-dsl" % http4sVersion % "test"
-    ),
+    // TODO: This is only temporary until http4s publishes for 2.13
+    // Replace this libDependencies and the two skips with just a
+    // libDeps for the two http4s libs
+    libraryDependencies := (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, v)) if v >= 13 => Seq.empty
+      case _ => libraryDependencies.value ++ Seq(
+        "org.http4s" %% "http4s-core" % http4sVersion,
+        "org.http4s" %% "http4s-dsl" % http4sVersion % "test"
+      )
+    }),
+    skip in compile := (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, v)) => v >= 13
+      case _ => false
+    }),
+    skip in publish := (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, v)) => v >= 13
+      case _ => false
+    }),
     buildOsgiBundle("com.ccadllc.cedi.dtrace.interop.http4s")
   ).dependsOn(core % "compile->compile;test->test", money % "compile->test", xb3 % "compile->test")
 
 lazy val readme = project.in(file("readme")).settings(commonSettings).settings(noPublish).enablePlugins(TutPlugin).settings(
-  tutTargetDirectory := baseDirectory.value / "..",
-  libraryDependencies ++= Seq(
-    "org.http4s" %% "http4s-dsl" % http4sVersion,
-    "org.http4s" %% "http4s-circe" % http4sVersion)
-).dependsOn(core, logging, money, xb3, http4s)
+  tutTargetDirectory := baseDirectory.value / ".."
+).dependsOn(core, logging)

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val catsCoreVersion = "1.4.0"
 
 lazy val circeVersion = "0.10.0"
 
-lazy val http4sVersion = "0.19.0-M2"
+lazy val http4sVersion = "0.19.0-M3"
 
 lazy val logbackVersion = "1.2.3"
 

--- a/core/src/main/scala/com/ccadllc/cedi/dtrace/Evaluator.scala
+++ b/core/src/main/scala/com/ccadllc/cedi/dtrace/Evaluator.scala
@@ -27,8 +27,7 @@ package com.ccadllc.cedi.dtrace
  */
 class Evaluator[A](
   val exceptionToFailure: Throwable => Option[FailureDetail],
-  val resultToFailure: A => Option[FailureDetail]
-)
+  val resultToFailure: A => Option[FailureDetail])
 
 /**
  * This companion object for `Evaluator` instances provides smart constructors and a `default` value should no

--- a/core/src/main/scala/com/ccadllc/cedi/dtrace/HeaderCodec.scala
+++ b/core/src/main/scala/com/ccadllc/cedi/dtrace/HeaderCodec.scala
@@ -25,7 +25,9 @@ import cats.Show
 final case class Header(name: Header.CaseInsensitiveName, value: Header.Value)
 object Header {
   final case class CaseInsensitiveName(value: String) {
-    override val hashCode: Int = value.toLowerCase.hashCode
+    /* Added to suppress equals/hashcode warning from compiler when using the `override val hashCode` idiom */
+    private val hc: Int = value.toLowerCase.hashCode
+    override def hashCode: Int = hc
     override def equals(other: Any): Boolean = other match {
       case CaseInsensitiveName(ov) => value.equalsIgnoreCase(ov)
       case _ => false

--- a/core/src/main/scala/com/ccadllc/cedi/dtrace/Span.scala
+++ b/core/src/main/scala/com/ccadllc/cedi/dtrace/Span.scala
@@ -15,14 +15,12 @@
  */
 package com.ccadllc.cedi.dtrace
 
-import java.time.Instant
-import java.time.temporal.ChronoUnit
+import cats.Functor
+import cats.effect.Sync
+import cats.implicits._
 
 import scala.concurrent.duration._
 import scala.language.higherKinds
-
-import cats.effect.Sync
-import cats.implicits._
 
 /**
  * Represents a single span for a distributed trace.  A span is the traced execution of an effectful program `F`.
@@ -30,7 +28,7 @@ import cats.implicits._
  *   of spans.
  * @param spanName - the human readable name of this span - it is the logical name of the effectful program whose execution
  *   this span is recording.
- * @param startTime - the `java.time.Instant` representing the timestamp at which the program started execution
+ * @param startTime - the [[TraceSystem#Time]] representing the point in time at which the program started execution
  * @param failure - the [[FailureDetail]] is present and provides a means to render the detail of a program execution failure
  *   if the execution failed; otherwise is it not present.
  * @param duration - the elapsed time of the execution of the program.
@@ -38,39 +36,38 @@ import cats.implicits._
  *   the program's inputs as well as its results.
  */
 case class Span(
-    spanId: SpanId,
-    spanName: Span.Name,
-    startTime: Instant,
-    failure: Option[FailureDetail],
-    duration: FiniteDuration,
-    notes: Vector[Note]
-) {
+  spanId: SpanId,
+  spanName: Span.Name,
+  startTime: TraceSystem.Time,
+  failure: Option[FailureDetail],
+  duration: FiniteDuration,
+  notes: Vector[Note]) {
 
   /**
    * Indicates whether or not this span is the root span of the overall trace.
    */
   val root: Boolean = spanId.root
 
-  private[dtrace] def newChild[F[_]: Sync](spanName: Span.Name): F[Span] = for {
-    startTime <- Span.nowInstant
+  private[dtrace] def newChild[F[_]: Sync](timer: TraceSystem.Timer[F], spanName: Span.Name): F[Span] = for {
+    startTime <- timer.time
     child <- spanId.newChild
   } yield Span(child, spanName, startTime, None, Duration.Zero, Vector.empty)
 
   private[dtrace] def setNotes(notes: Vector[Note]): Span =
     copy(notes = notes)
 
-  private[dtrace] def updateStartTime[F[_]: Sync]: F[Span] =
-    Span.nowInstant map { t => copy(startTime = t) }
+  private[dtrace] def updateStartTime[F[_]: Functor](timer: TraceSystem.Timer[F]): F[Span] =
+    timer.time map { t => copy(startTime = t) }
 
-  private[dtrace] def finishSuccess[F[_]: Sync]: F[Span] =
-    finish(None)
+  private[dtrace] def finishSuccess[F[_]: Functor](timer: TraceSystem.Timer[F]): F[Span] =
+    finish(timer, None)
 
-  private[dtrace] def finishFailure[F[_]: Sync](detail: FailureDetail): F[Span] =
-    finish(Some(detail))
+  private[dtrace] def finishFailure[F[_]: Functor](timer: TraceSystem.Timer[F], detail: FailureDetail): F[Span] =
+    finish(timer, Some(detail))
 
-  private def finish[F[_]: Sync](failure: Option[FailureDetail]): F[Span] =
-    Span.nowInstant map { endTime =>
-      copy(failure = failure, duration = FiniteDuration(ChronoUnit.MICROS.between(startTime, endTime), MICROSECONDS))
+  private def finish[F[_]: Functor](timer: TraceSystem.Timer[F], failure: Option[FailureDetail]): F[Span] =
+    timer.time map { endTime =>
+      copy(failure = failure, duration = FiniteDuration(endTime.value - startTime.value, endTime.unit))
     }
 
   override def toString: String =
@@ -78,29 +75,29 @@ case class Span(
 }
 
 object Span {
-  case class Name(value: String) { override def toString: String = value }
+  final case class Name(value: String) { override def toString: String = value }
 
   /**
    * Creates a root span by generating a root [[SpanId]].
+   * @param timer - the [[TraceSystem#Timer]] used to measure the span.
    * @param spanName - the human readable name of this span.
    * @param notes - a variable argument list of [[Note]]s, metadata to annotate this span.
    * @return newSpan - an effectful program which when run will result in a new root span.
    */
-  def root[F[_]: Sync](spanName: Name, notes: Note*): F[Span] = SpanId.root flatMap { newSpan(_, spanName, notes: _*) }
+  def root[F[_]: Sync](timer: TraceSystem.Timer[F], spanName: Name, notes: Note*): F[Span] =
+    SpanId.root flatMap { newSpan(timer, _, spanName, notes: _*) }
 
   /**
    * Create a new child of the passed-in [[SpanId]].
+   * @param timer - the [[TraceSystem#Timer]] used to measure the span.
    * @param spanId - the [[SpanId]] containing the identity for which a child span will be created.
    * @param spanName - the human readable name of this span.
    * @param notes - a variable argument list of [[Note]]s, metadata to annotate this span.
    * @return newSpan - an effectful program which when run will result in a new child span.
    */
-  def newChild[F[_]: Sync](spanId: SpanId, spanName: Name, notes: Note*): F[Span] = spanId.newChild flatMap { newSpan(_, spanName, notes: _*) }
+  def newChild[F[_]: Sync](timer: TraceSystem.Timer[F], spanId: SpanId, spanName: Name, notes: Note*): F[Span] =
+    spanId.newChild flatMap { newSpan(timer, _, spanName, notes: _*) }
 
-  private[dtrace] val empty: Span = Span(SpanId.empty, Span.Name("empty"), Instant.EPOCH, None, 0.seconds, Vector.empty)
-
-  private def nowInstant[F[_]](implicit F: Sync[F]): F[Instant] = F.delay(Instant.now)
-
-  private def newSpan[F[_]: Sync](spanId: SpanId, spanName: Span.Name, notes: Note*): F[Span] =
-    nowInstant map { Span(spanId, spanName, _, None, Duration.Zero, notes.toVector) }
+  private def newSpan[F[_]: Functor](timer: TraceSystem.Timer[F], spanId: SpanId, spanName: Span.Name, notes: Note*): F[Span] =
+    timer.time map { Span(spanId, spanName, _, None, Duration.Zero, notes.toVector) }
 }

--- a/core/src/main/scala/com/ccadllc/cedi/dtrace/TraceSystem.scala
+++ b/core/src/main/scala/com/ccadllc/cedi/dtrace/TraceSystem.scala
@@ -15,9 +15,16 @@
  */
 package com.ccadllc.cedi.dtrace
 
-import cats.Applicative
+import cats._
+import cats.effect.{ Clock, Sync }
+import cats.implicits._
+
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.TimeUnit
 
 import scala.language.higherKinds
+import scala.util.matching.Regex
 
 /**
  * System level configuration for the trace system.
@@ -26,10 +33,11 @@ import scala.language.higherKinds
  *   node, deployment, and environment information).
  * @param emitter - [[TraceSystem#Emitter]] responsible for actually recording the span information for a distributed trace
  *   to some external sink (e.g., log file, remote database, JMX, etc.).
- * @tparam F - an effectful program type used to execute the `Emitter`.
+ * @param timer - [[TraceSystem#Timer]] responsible for generating timer to measure performance of [[Span]]s.
+ * @tparam F - an effectful program type used to execute the `Emitter` and `Timer`.
  */
-case class TraceSystem[F[_]](metadata: Map[String, String], emitter: TraceSystem.Emitter[F]) {
-  override def toString: String = s"[metadata=${metadata.mkString(",")}] [emitter=${emitter.description}]"
+case class TraceSystem[F[_]](metadata: Map[String, String], emitter: TraceSystem.Emitter[F], timer: TraceSystem.Timer[F]) {
+  override def toString: String = s"[metadata=${metadata.mkString(",")}] [emitter=${emitter.description}] [timer=${timer.description}]"
 }
 
 object TraceSystem {
@@ -54,12 +62,82 @@ object TraceSystem {
     def description: String
   }
 
-  /* An empty trace system which includes a no-op emitter - used internally by typeclass implementations which need an empty/pure/initial value. */
-  private[dtrace] def empty[F[_]](implicit F: Applicative[F]): TraceSystem[F] = TraceSystem[F](
-    Map.empty,
-    new Emitter[F] {
-      override def emit(tc: TraceContext[F]): F[Unit] = F.pure(())
-      override val description: String = "Empty Emitter"
+  /**
+   * Represents a point of time.  Might be real-time or monotonic.  The [[Timer]] generates these
+   * based on the associated `cats.effect.Clock`.  For a [[Timer#Monotonic]], the `cats.effect.Clock#monotonic`
+   * will be used; otherwise, if it is a [[Timer#RealTime]], the `cats.effect.Clock#realTime` will be used.
+   */
+  final case class Time(value: Long, unit: TimeUnit, source: Time.Source) {
+    override def toString: String = source match {
+      case Time.Source.Monotonic => s"$value ${unit.toString.toLowerCase}"
+      case Time.Source.RealTime => DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochMilli(TimeUnit.MILLISECONDS.convert(value, unit)))
     }
-  )
+  }
+  object Time {
+    sealed abstract class Source extends Product with Serializable
+    object Source {
+      case object Monotonic extends Source
+      case object RealTime extends Source
+      def fromString(str: String): Either[FailureDetail, Source] = if (str === Monotonic.toString) Right(Monotonic)
+      else if (str === RealTime.toString) Right(RealTime) else Left(FailureDetail(s"$str was neither $Monotonic nor $RealTime"))
+    }
+    final val TimeRegex: Regex = "([0-9]+) ([a-z]+)".r
+
+    implicit val show: Show[Time] = Show.fromToString
+
+    def parse(str: String): Either[FailureDetail, Time] = {
+      def realTimeParse(str: String): Either[FailureDetail, Time] = Either.catchNonFatal {
+        Time(TimeUnit.MILLISECONDS.toMicros(Instant.parse(str).toEpochMilli), TimeUnit.MICROSECONDS, Time.Source.RealTime)
+      }.leftMap(FailureDetail(_))
+      def monotonicParse(str: String): Either[FailureDetail, Time] = str match {
+        case TimeRegex(valueStr, unitStr) => for {
+          value <- Either.catchNonFatal { valueStr.toLong }.leftMap {
+            _ => FailureDetail(s"Could not parse $valueStr as a Long from $str for Time")
+          }
+          unit <- Either.catchNonFatal { TimeUnit.valueOf(unitStr.toUpperCase) }.leftMap {
+            e => FailureDetail(s"Could not parse $unitStr as a TimeUnit from $str for Time (${e.getMessage})")
+          }
+        } yield Time(value, unit, Time.Source.Monotonic)
+        case other => Left(FailureDetail(s"Could not parse $str to a Time value"))
+      }
+      realTimeParse(str).fold(
+        rte => monotonicParse(str).leftMap(mte => FailureDetail(s"Could parse $str as neither a real-time ($rte) or monotonic ($mte) TraceSystem.Time")),
+        Right(_))
+    }
+  }
+
+  /**
+   * This ADT represents a time generator using the associated `cats.effect.Clock`, using the asssociated
+   * `java.util.concurrent.TimeUnit`. The valid sub-types are [[Timer#Monotonic]] or [[Timer#RealTime]]
+   * where the `cats.effect.Clock#monotonic` or `cats.effect.Clock#realTime` functions will be used to
+   * generate a point in time, used in determining the execution time of a [[Span]].
+   */
+  sealed abstract class Timer[F[_]] extends Product with Serializable {
+    def clock: Clock[F]
+    def unit: TimeUnit
+    def time(implicit F: Functor[F]): F[Time]
+    def translate[G[_]](trans: F ~> G): Timer[G]
+    def description: String
+  }
+  object Timer {
+    final case class Monotonic[F[_]](clock: Clock[F], unit: TimeUnit = TimeUnit.NANOSECONDS) extends Timer[F] {
+      val description: String = s"A monotonic generator for time in units of $unit"
+      def time(implicit F: Functor[F]): F[Time] = clock.monotonic(unit).map(Time(_, unit, Time.Source.Monotonic))
+      def translate[G[_]](trans: F ~> G): Timer[G] = Monotonic(transClock(clock, trans), unit)
+    }
+    final case class RealTime[F[_]](clock: Clock[F], unit: TimeUnit = TimeUnit.MICROSECONDS) extends Timer[F] {
+      val description: String = s"A real-time generator for time in units of $unit"
+      def time(implicit F: Functor[F]): F[Time] = clock.realTime(unit).map(Time(_, unit, Time.Source.RealTime))
+      def translate[G[_]](trans: F ~> G): Timer[G] = Monotonic(transClock(clock, trans), unit)
+    }
+    def monotonic[F[_]: Sync](unit: TimeUnit): Timer[F] = Monotonic(Clock.create[F], unit)
+    def realTime[F[_]: Sync](unit: TimeUnit): Timer[F] = RealTime(Clock.create[F], unit)
+
+    private def transClock[F[_], G[_]](clock: Clock[F], trans: F ~> G): Clock[G] = new Clock[G] {
+      def realTime(unit: TimeUnit): G[Long] = trans(clock.realTime(unit))
+      def monotonic(unit: TimeUnit): G[Long] = trans(clock.monotonic(unit))
+    }
+  }
+  def monotonicTimer[F[_]: Sync]: Timer[F] = Timer.monotonic[F](TimeUnit.NANOSECONDS)
+  def realTimeTimer[F[_]: Sync]: Timer[F] = Timer.realTime[F](TimeUnit.MICROSECONDS)
 }

--- a/core/src/main/scala/com/ccadllc/cedi/dtrace/TraceT.scala
+++ b/core/src/main/scala/com/ccadllc/cedi/dtrace/TraceT.scala
@@ -450,6 +450,9 @@ object TraceT extends TraceTPolyFunctions with TraceTInstances {
    * TODO: Look into a better construct such that we don't have to depend on the
    * underlying `F` having a `Monad[F]` in order to make the overall `TraceT[F, ?]`
    * stacksafe as its very brittle and non-type-safe.
+   *
+   * This was taken pretty much whole cloth from [[https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/data/Kleisli.scala#L104 Kleisli]]
+   * in order to make `cats-effect` typeclasses which are `Kleisli` stack-safe.
    */
   private[dtrace] def suspendEffect[F[_], A](toEffect: TraceContext[F] => F[A])(implicit F: Functor[F]): TraceT[F, A] = F match {
     case m: Monad[F] @unchecked => TraceT { tc => m.flatMap(m.pure(tc))(toEffect) }

--- a/core/src/main/scala/com/ccadllc/cedi/dtrace/TraceT.scala
+++ b/core/src/main/scala/com/ccadllc/cedi/dtrace/TraceT.scala
@@ -15,13 +15,12 @@
  */
 package com.ccadllc.cedi.dtrace
 
-import cats.{ Applicative, Functor, Monad, MonadError, ~> }
+import cats._
 import cats.effect._
 import cats.implicits._
 
-import java.util.concurrent.TimeUnit
-
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.{ FiniteDuration, TimeUnit }
 import scala.language.higherKinds
 
 /**
@@ -35,21 +34,179 @@ import scala.language.higherKinds
  * @tparam F - a type constructor representing the effect which is traced.
  * @tparam A - the result of the effect which is traced.
  */
-final class TraceT[F[_], A](private[dtrace] val tie: TraceContext[F] => F[A]) { self =>
+final class TraceT[F[_], A](private[dtrace] val toEffect: TraceContext[F] => F[A]) { self =>
+
+  /**
+   * Given the (usually) root [[TraceContext]], convert this `TraceT[A]` to its underlying effectful program `F[A]`. In addition, when the effectful program
+   * is run, further annotate the associated [[Span]] with [[Note]]s derived from the result of its run, using the passed-in function.
+   * @param tc the [[TraceContext]] to use in generating the trace -- usually this contains the root [[Span]] (or at least the root
+   *   span of trace for the virtual machine it is running in).
+   * @param notes a variable argument list of [[Note]]s used to annotate the current [[Span]].
+   * @param resultAnnotator a partial function which is passed an `Either[Throwable, A]` as the result of the underlying program's run and which
+   *   returns a `Vector` of zero or more [[Note]]s, possibly derived from the input result.
+   * @return the underlying effectful program `F[A]` that, when run, will calculate and record the trace of its execution.
+   */
+  def annotatedTrace(tc: TraceContext[F], notes: Note*)(resultAnnotator: PartialFunction[Either[Throwable, A], Vector[Note]])(implicit F: Sync[F]): F[A] =
+    annotatedTrace(tc, Evaluator.default[A], notes: _*)(resultAnnotator)
+
+  /**
+   * Given the (usually) root [[TraceContext]], convert this `TraceT[A]` to its underlying effectful program `F[A]`, using the passed-in [[Evaluator]]
+   * to determine the program's success/failure status. In addition, when the effectful program
+   * is run, further annotate the associated [[Span]] with [[Note]]s derived from the result of its run, using the passed-in function.
+   * @param tc the [[TraceContext]] to use in generating the trace -- usually this contains the root [[Span]] (or at least the root
+   *   span of trace for the virtual machine it is running in).
+   * @param evaluator an [[Evaluator]] which converts either a `Throwable` or `A` to an optional [[FailureDetail]]
+   * @param notes a variable argument list of [[Note]]s used to annotate the current [[Span]].
+   * @param resultAnnotator a partial function which is passed an `Either[Throwable, A]` as the result of the underlying program's run and which
+   *   returns a `Vector` of zero or more [[Note]]s, possibly derived from the input result.
+   * @return the underlying effectful program `F[A]` that, when run, will calculate and record the trace of its execution.
+   */
+  def annotatedTrace(
+    tc: TraceContext[F],
+    evaluator: Evaluator[A],
+    notes: Note*)(resultAnnotator: PartialFunction[Either[Throwable, A], Vector[Note]])(implicit F: Sync[F]): F[A] =
+    tc.updateStartTime flatMap { updated =>
+      toEffect(updated).attempt.flatMap { eOrR =>
+        val annotatedTc = updated.setNotes(notes.toVector ++ resultAnnotator.applyOrElse(eOrR, (_: Either[Throwable, A]) => Vector.empty))
+        eOrR match {
+          case Right(r) => evaluator.resultToFailure(r).fold(annotatedTc.emitSuccess)(updated.emitFailure) map { _ => r }
+          case Left(e) => evaluator.exceptionToFailure(e).fold(annotatedTc.emitSuccess)(annotatedTc.emitFailure) flatMap { _ => F.raiseError(e) }
+        }
+      }
+    }
+
+  /**
+   * When passed a top-level [[TraceContext]], convert this `TraceT` into its underlying effectful
+   * program enhanced with the capability of tracing its execution.
+   * @param tc the top-level [[TraceContext]] to apply to the `TraceT` in order to transform it
+   *   to an `F[A]`.
+   * @return the underlying `F[A]` enhanced to trace its execution.
+   */
+  def apply(tc: TraceContext[F]): F[A] = toEffect(tc)
+
+  /**
+   * Transforms this `TraceT[F, A]` to a `TraceT[F, Either[Throwable, A]]` where the left-hand side of the
+   * `Either` represents a failure of the underlying program `F` and the right-hand side represents the
+   * successful result.  It is a way of handling non-fatal errors by turning them into `scala.util.Either` values.
+   * @return a `TraceT[F, Either[Throwable, A]]` indicating that the underlying effectful program `F`
+   *   will not fail at the program level but rather will indicate success/failure at the application level via its
+   *   `Either[Throwable, A]` result type.
+   */
+  def attempt(implicit F: MonadError[F, Throwable]): TraceT[F, Either[Throwable, A]] =
+    TraceT.suspendEffect(toEffect(_).attempt)
+
+  /**
+   * Transforms this `TraceT[F, A]` to an equivalent `TraceT[F, A]` where a best-effort will be made
+   * to execute the passed-in function on the finish of the underlying effectful program.  The function can't
+   * be guaranteed to run in the face of interrupts, etc.  It depends on the nature of the effectful program
+   * itself.
+   * @param f function which is passed an optional `Throwable` - defined if the program failed and
+   *   returns a `TraceT[F, Unit]`, a program run only for its effect.
+   * @return new `TraceT[F, A]` with the error handling of the aforementioned `f` function
+   */
+  @deprecated("Use bracketCase instead", "1.4.0")
+  def bestEffortOnFinish(f: Option[Throwable] => TraceT[F, Unit])(implicit F: MonadError[F, Throwable]): TraceT[F, A] =
+    TraceT.suspendEffect(tc => toEffect(tc).bestEffortOnFinish(f(_).toEffect(tc)))
+
+  /**
+   * Returns a `TraceT[F, ?]` action that treats the source task as the
+   * acquisition of a resource, which is then exploited by the `use`
+   * function and then `released`.
+   *
+   * The `bracket` operation is the equivalent of the
+   * `try {} catch {} finally {}` statements from mainstream languages.
+   *
+   * The `bracket` operation installs the necessary exception handler
+   * to release the resource in the event of an exception being raised
+   * during the computation, or in case of cancellation.
+   *
+   * If an exception is raised, then `bracket` will re-raise the
+   * exception ''after'' performing the `release`. If the resulting
+   * task gets canceled, then `bracket` will still perform the
+   * `release`, but the yielded task will be non-terminating
+   * (equivalent with `IO.never` when `F` is `IO`, for example]).
+   *
+   * See `IO.bracket` scaladoc for further detail.
+   *
+   * @see [[bracketCase]]
+   *
+   * @param use is a function that evaluates the resource yielded by
+   *        the source, yielding a result that will get generated by
+   *        the task returned by this `bracket` function
+   *
+   * @param release is a function that gets called after `use`
+   *        terminates, either normally or in error, or if it gets
+   *        canceled, receiving as input the resource that needs to
+   *        be released
+   */
+  def bracket[B](use: A => TraceT[F, B])(release: A => TraceT[F, Unit])(implicit F: Bracket[F, Throwable]): TraceT[F, B] =
+    bracketCase(use)((a, _) => release(a))
+
+  /**
+   * Returns a new `TraceT[F, ?]` task that treats the source task as the
+   * acquisition of a resource, which is then exploited by the `use`
+   * function and then `released`, with the possibility of
+   * distinguishing between normal termination and cancellation, such
+   * that an appropriate release of resources can be executed.
+   *
+   * The `bracketCase` operation is the equivalent of
+   * `try {} catch {} finally {}` statements from mainstream languages
+   * when used for the acquisition and release of resources.
+   *
+   * The `bracketCase` operation installs the necessary exception handler
+   * to release the resource in the event of an exception being raised
+   * during the computation, or in case of cancellation.
+   *
+   * In comparison with the simpler [[bracket]] version, this one
+   * allows the caller to differentiate between normal termination,
+   * termination in error and cancellation via an `ExitCase`
+   * parameter.
+   *
+   * @see [[bracket]]
+   *
+   * @param use is a function that evaluates the resource yielded by
+   *        the source, yielding a result that will get generated by
+   *        this function on evaluation
+   *
+   * @param release is a function that gets called after `use`
+   *        terminates, either normally or in error, or if it gets
+   *        canceled, receiving as input the resource that needs that
+   *        needs release, along with the result of `use`
+   *        (cancellation, error or successful result)
+   */
+  def bracketCase[B](use: A => TraceT[F, B])(release: (A, ExitCase[Throwable]) => TraceT[F, Unit])(implicit F: Bracket[F, Throwable]): TraceT[F, B] =
+    TraceT.suspendEffect(tc => F.bracketCase(toEffect(tc))(use(_).toEffect(tc))(release(_, _).toEffect(tc)))
 
   /**
    * Generates a new `TraceT[F, B]` from this instance using the supplied function `A => TraceT[F, B]`.
    * @param f function from `A` => `TraceT[F, B]`
+   * _Note that because `TraceT[F, ?]` needs to apply its function of `TraceContext[F] => F[?]` in order to
+   * map over the underlying value, in order for it to be stack-safe, `F` needs to have a `Monad[F]` in
+   * implicit scope in order to create a pure F in the suspension of the effect.  This isn't a compile-time
+   * requirement as you can have a non-stack-safe flatMap with just a `FlatMap[F]` in scope  as long
+   * as you know you will not have deeply nested maps._
    */
-  def flatMap[B](f: A => TraceT[F, B])(implicit F: Monad[F]): TraceT[F, B] =
-    TraceT { tc => tie(tc).flatMap { f andThen { _.tie(tc) } } }
+  def flatMap[B](f: A => TraceT[F, B])(implicit F: FlatMap[F]): TraceT[F, B] =
+    TraceT.suspendEffect(tc => toEffect(tc).flatMap(f(_).toEffect(tc)))
+
+  /**
+   * Handles an error by mapping it to a new `TraceT`.
+   * @param f handler function which maps an error to a new `TraceT`, possibly by recovering from it
+   * @return new `TraceT[F, A]` with error handling of the aforementioned `f` function
+   */
+  def handleErrorWith(f: Throwable => TraceT[F, A])(implicit F: MonadError[F, Throwable]): TraceT[F, A] =
+    TraceT.suspendEffect(tc => toEffect(tc).handleErrorWith(t => f(t).toEffect(tc)))
 
   /**
    * Generates a new `TraceT[F, B]` from this instance using the supplied function `A => B`.
-   * @param f function from `A` => `TraceT[F, B]`
+   * @param f function from `A` => `B`
+   * _Note that because `TraceT[F, ?]` needs to apply its function of `TraceContext[F] => F[?]` in order to
+   * map over the underlying value, in order for it to be stack-safe, `F` needs to have a `Monad[F]` in
+   * implicit scope.  This isn't a compile-time requirement as you can have a non-stack-safe map as long
+   * as you know you will not have deeply nested maps._
    */
   def map[B](f: A => B)(implicit F: Functor[F]): TraceT[F, B] =
-    TraceT { tc => tie(tc).map(f) }
+    TraceT.suspendEffect(toEffect(_).map(f))
 
   /**
    * Creates a new child [[Span]] from the current span represented by this instance, using the
@@ -91,8 +248,7 @@ final class TraceT[F[_], A](private[dtrace] val tie: TraceContext[F] => F[A]) { 
    * @return a new instance of `TraceT` representing a child span of `this`.
    */
   def newAnnotatedSpan(
-    spanName: Span.Name, notes: Note*
-  )(resultAnnotator: PartialFunction[Either[Throwable, A], Vector[Note]])(implicit F: Sync[F]): TraceT[F, A] =
+    spanName: Span.Name, notes: Note*)(resultAnnotator: PartialFunction[Either[Throwable, A], Vector[Note]])(implicit F: Sync[F]): TraceT[F, A] =
     newAnnotatedSpan(spanName, Evaluator.default[A], notes: _*)(resultAnnotator)
 
   /**
@@ -137,12 +293,8 @@ final class TraceT[F[_], A](private[dtrace] val tie: TraceContext[F] => F[A]) { 
   def newAnnotatedSpan(
     spanName: Span.Name,
     evaluator: Evaluator[A],
-    notes: Note*
-  )(resultAnnotator: PartialFunction[Either[Throwable, A], Vector[Note]])(implicit F: Sync[F]): TraceT[F, A] = TraceT { tc =>
-    for {
-      t <- tc.childSpan(spanName)
-      r <- annotatedTrace(t, evaluator, notes: _*)(resultAnnotator)
-    } yield r
+    notes: Note*)(resultAnnotator: PartialFunction[Either[Throwable, A], Vector[Note]])(implicit F: Sync[F]): TraceT[F, A] = TraceT.suspendEffect { tc =>
+    tc.childSpan(spanName).flatMap { annotatedTrace(_, evaluator, notes: _*)(resultAnnotator) }
   }
 
   /**
@@ -156,19 +308,6 @@ final class TraceT[F[_], A](private[dtrace] val tie: TraceContext[F] => F[A]) { 
     annotatedTrace(tc, notes: _*)(PartialFunction.empty)
 
   /**
-   * Given the (usually) root [[TraceContext]], convert this `TraceT[A]` to its underlying effectful program `F[A]`. In addition, when the effectful program
-   * is run, further annotate the associated [[Span]] with [[Note]]s derived from the result of its run, using the passed-in function.
-   * @param tc the [[TraceContext]] to use in generating the trace -- usually this contains the root [[Span]] (or at least the root
-   *   span of trace for the virtual machine it is running in).
-   * @param notes a variable argument list of [[Note]]s used to annotate the current [[Span]].
-   * @param resultAnnotator a partial function which is passed an `Either[Throwable, A]` as the result of the underlying program's run and which
-   *   returns a `Vector` of zero or more [[Note]]s, possibly derived from the input result.
-   * @return the underlying effectful program `F[A]` that, when run, will calculate and record the trace of its execution.
-   */
-  def annotatedTrace(tc: TraceContext[F], notes: Note*)(resultAnnotator: PartialFunction[Either[Throwable, A], Vector[Note]])(implicit F: Sync[F]): F[A] =
-    annotatedTrace(tc, Evaluator.default[A], notes: _*)(resultAnnotator)
-
-  /**
    * Given the (usually) root [[TraceContext]], convert this `TraceT[A]` to its underlying effectful program `F[A]`, using the passed-in [[Evaluator]]
    * to determine the program's success/failure status.
    * @param tc the [[TraceContext]] to use in generating the trace -- usually this contains the root [[Span]] (or at least the root
@@ -179,72 +318,6 @@ final class TraceT[F[_], A](private[dtrace] val tie: TraceContext[F] => F[A]) { 
    */
   def trace(tc: TraceContext[F], evaluator: Evaluator[A], notes: Note*)(implicit F: Sync[F]): F[A] =
     annotatedTrace(tc, evaluator, notes: _*)(PartialFunction.empty)
-
-  /**
-   * Given the (usually) root [[TraceContext]], convert this `TraceT[A]` to its underlying effectful program `F[A]`, using the passed-in [[Evaluator]]
-   * to determine the program's success/failure status. In addition, when the effectful program
-   * is run, further annotate the associated [[Span]] with [[Note]]s derived from the result of its run, using the passed-in function.
-   * @param tc the [[TraceContext]] to use in generating the trace -- usually this contains the root [[Span]] (or at least the root
-   *   span of trace for the virtual machine it is running in).
-   * @param evaluator an [[Evaluator]] which converts either a `Throwable` or `A` to an optional [[FailureDetail]]
-   * @param notes a variable argument list of [[Note]]s used to annotate the current [[Span]].
-   * @param resultAnnotator a partial function which is passed an `Either[Throwable, A]` as the result of the underlying program's run and which
-   *   returns a `Vector` of zero or more [[Note]]s, possibly derived from the input result.
-   * @return the underlying effectful program `F[A]` that, when run, will calculate and record the trace of its execution.
-   */
-  def annotatedTrace(
-    tc: TraceContext[F],
-    evaluator: Evaluator[A],
-    notes: Note*
-  )(resultAnnotator: PartialFunction[Either[Throwable, A], Vector[Note]])(implicit F: Sync[F]): F[A] =
-    tc.updateStartTime flatMap { updated =>
-      tie(updated).attempt.flatMap { eOrR =>
-        val annotatedTc = updated.setNotes(notes.toVector ++ resultAnnotator.applyOrElse(eOrR, (_: Either[Throwable, A]) => Vector.empty))
-        eOrR match {
-          case Right(r) => evaluator.resultToFailure(r).fold(annotatedTc.emitSuccess)(updated.emitFailure) map { _ => r }
-          case Left(e) => evaluator.exceptionToFailure(e).fold(annotatedTc.emitSuccess)(annotatedTc.emitFailure) flatMap { _ => F.raiseError(e) }
-        }
-      }
-    }
-
-  /**
-   * Transforms this `TraceT[F, A]` to a `TraceT[F, Either[Throwable, A]]` where the left-hand side of the
-   * `Either` represents a failure of the underlying program `F` and the right-hand side represents the
-   * successful result.  It is a way of handling non-fatal errors by turning them into `scala.util.Either` values.
-   * @return a `TraceT[F, Either[Throwable, A]]` indicating that the underlying effectful program `F`
-   *   will not fail at the program level but rather will indicate success/failure at the application level via its
-   *   `Either[Throwable, A]` result type.
-   */
-  def attempt(implicit F: MonadError[F, Throwable]): TraceT[F, Either[Throwable, A]] = TraceT { tie(_).attempt }
-
-  /**
-   * Transforms this `TraceT[F, A]` to an equivalent `TraceT[F, A]` where a best-effort will be made
-   * to execute the passed-in function on the finish of the underlying effectful program.  The function can't
-   * be guaranteed to run in the face of interrupts, etc.  It depends on the nature of the effectful program
-   * itself.
-   * @param f function which is passed an optional `Throwable` - defined if the program failed and
-   *   returns a `TraceT[F, Unit]`, a program run only for its effect.
-   * @return new `TraceT[F, A]` with the error handling of the aforementioned `f` function
-   */
-  def bestEffortOnFinish(f: Option[Throwable] => TraceT[F, Unit])(implicit F: MonadError[F, Throwable]): TraceT[F, A] =
-    TraceT { tc => tie(tc).bestEffortOnFinish(f(_).tie(tc)) }
-
-  /**
-   * Handles an error by mapping it to a new `TraceT`.
-   * @param f handler function which maps an error to a new `TraceT`, possibly by recovering from it
-   * @return new `TraceT[F, A]` with error handling of the aforementioned `f` function
-   */
-  def handleErrorWith(f: Throwable => TraceT[F, A])(implicit F: MonadError[F, Throwable]): TraceT[F, A] =
-    TraceT { tc => tie(tc).handleErrorWith(t => f(t).tie(tc)) }
-
-  /**
-   * When passed a top-level [[TraceContext]], convert this `TraceT` into its underlying effectful
-   * program enhanced with the capability of tracing its execution.
-   * @param tc the top-level [[TraceContext]] to apply to the `TraceT` in order to transform it
-   *   to an `F[A]`.
-   * @return the underlying `F[A]` enhanced to trace its execution.
-   */
-  def apply(tc: TraceContext[F]): F[A] = tie(tc)
 }
 
 /**
@@ -253,46 +326,13 @@ final class TraceT[F[_], A](private[dtrace] val tie: TraceContext[F] => F[A]) { 
  */
 object TraceT extends TraceTPolyFunctions with TraceTInstances {
 
-  private[dtrace] def apply[F[_], A](tie: TraceContext[F] => F[A]): TraceT[F, A] = new TraceT(tie)
+  private[dtrace] def apply[F[_], A](toEffect: TraceContext[F] => F[A]): TraceT[F, A] = new TraceT(toEffect)
 
   /**
    * Ask for the current `TraceContext[F]` in a `TraceT`.
    * @return a `TraceContext[F]` wrapped in a `TraceT`.
    */
   def ask[F[_]](implicit F: Applicative[F]): TraceT[F, TraceContext[F]] = apply { F.pure }
-
-  /**
-   * Lifts a value `A` into a `TraceT[F, A]`.
-   * @param a the pure value `A` to lift into a `TraceT` context.
-   * @return a pure value `A` wrapped in a `TraceT`.
-   */
-  def pure[F[_], A](a: A)(implicit F: Applicative[F]): TraceT[F, A] = toTraceT(F.pure(a))
-
-  /**
-   * Lifts the non-strict, possibly impure expression computing `A` into a `TraceT[F, A]`
-   * context.
-   * @param a the non-strict expression computing `A` to lift into a `TraceT` context.
-   * @return a non-strict expression which computes `A` lifted into a `TraceT`.
-   */
-  def delay[F[_], A](a: => A)(implicit F: Sync[F]): TraceT[F, A] = toTraceT(F.delay(a))
-
-  /**
-   * Lifts the non-strict, possibly impure expression computing a `TraceT[F, A]` into a `TraceT[F, A]`.
-   * The expression is suspended until the outer `TraceT` returned is run.
-   * @param t the non-strict expression computing `TraceT[F, A]` to lift into a `TraceT` context suspended
-   *   until the outer `TraceT` is run.
-   * @return a non-strict expression which computes `TraceT[F, A]` lifted into a `TraceT` in
-   *   a suspended state until the outer `TraceT` is run.
-   */
-  def suspend[F[_], A](t: => TraceT[F, A])(implicit F: Sync[F]): TraceT[F, A] =
-    toTraceT(F.delay(t)).flatMap(identity)
-
-  /**
-   * Creates a failed `TraceT`, to create a failed underlying program, lifted to a `TraceT`.
-   * @param t the `Throwable` with which to fail the underlying program.
-   * @return the `TraceT[F, A]` in a failed state.
-   */
-  def raiseError[F[_], A](t: Throwable)(implicit F: MonadError[F, Throwable]): TraceT[F, A] = toTraceT(F.raiseError(t): F[A])
 
   /**
    * Creates a simple, noncancelable `TraceT[F, A]` instance that
@@ -308,6 +348,21 @@ object TraceT extends TraceTPolyFunctions with TraceTInstances {
   def async[F[_], A](cb: (Either[Throwable, A] => Unit) => Unit)(implicit F: Async[F]): TraceT[F, A] = toTraceT(F.async(cb))
 
   /**
+   * Creates a simple, noncancelable `TraceT[F, A]` instance that
+   * executes an asynchronous process on evaluation. Differentiated from `async`
+   * in that the callback returns an effect.
+   *
+   * The given function is being injected with a side-effectful
+   * callback for signaling the final result of an asynchronous
+   * process.
+   *
+   * @param k is a function that should be called with a
+   *       callback for signaling the result once it is ready
+   */
+  def asyncF[F[_], A](cb: (Either[Throwable, A] => Unit) => TraceT[F, Unit])(implicit F: Async[F]): TraceT[F, A] =
+    TraceT.suspendEffect { tc => F.asyncF(cb(_).toEffect(tc)) }
+
+  /**
    * Creates a cancelable `TraceT[F, A]` instance that executes an
    * asynchronous process on evaluation.
    *
@@ -315,12 +370,60 @@ object TraceT extends TraceTPolyFunctions with TraceTInstances {
    * being injected with a side-effectful callback, to be called
    * when the asynchronous process is complete with a final result.
    */
-  def cancelable[F[_], A](k: (Either[Throwable, A] => Unit) => IO[Unit])(implicit F: Concurrent[F]): TraceT[F, A] = toTraceT(F.cancelable(k))
+  def cancelable[F[_], A](k: (Either[Throwable, A] => Unit) => CancelToken[TraceT[F, ?]])(implicit F: Concurrent[F]): TraceT[F, A] =
+    TraceT.suspendEffect { tc => F.cancelable(k(_).toEffect(tc)) }
 
   /**
-   * Defines a conversion from [[IO]] in terms of the `Concurrent` type class.
+   * Generate a `ContextShift[TraceT[F, ?]]` given a `ContextShift[F] and `Monad[F]` in implicit scope.
+   */
+  def contextShift[F[_]: Monad: ContextShift]: ContextShift[TraceT[F, ?]] = implicitly[ContextShift[TraceT[F, ?]]]
+
+  /**
+   * Lifts the non-strict, possibly impure expression computing `A` into a `TraceT[F, A]`
+   * context.
+   * @param a the non-strict expression computing `A` to lift into a `TraceT` context.
+   * @return a non-strict expression which computes `A` lifted into a `TraceT`.
+   */
+  def delay[F[_], A](a: => A)(implicit F: Sync[F]): TraceT[F, A] = toTraceT(F.delay(a))
+
+  /**
+   * Defines a conversion from `IO` in terms of the `Concurrent` type class.
    */
   def liftIO[F[_], A](ioa: IO[A])(implicit F: Concurrent[F]): TraceT[F, A] = toTraceT(F.liftIO(ioa))
+
+  /**
+   * Lifts a value `A` into a `TraceT[F, A]`.
+   * @param a the pure value `A` to lift into a `TraceT` context.
+   * @return a pure value `A` wrapped in a `TraceT`.
+   */
+  def pure[F[_], A](a: A)(implicit F: Applicative[F]): TraceT[F, A] = toTraceT(F.pure(a))
+
+  /**
+   * Creates a failed `TraceT`, to create a failed underlying program, lifted to a `TraceT`.
+   * @param t the `Throwable` with which to fail the underlying program.
+   * @return the `TraceT[F, A]` in a failed state.
+   */
+  def raiseError[F[_], A](t: Throwable)(implicit F: MonadError[F, Throwable]): TraceT[F, A] = toTraceT(F.raiseError(t): F[A])
+
+  /**
+   * Asynchronous boundary described as an effectful `TraceT[F, Unit managed
+   * by the provided `ContextShift`.
+   *
+   * This operation can be used in `flatMap` chains to "shift" the
+   * continuation of the run-loop to another thread or call stack.
+   */
+  def shift[F[_]](implicit cs: ContextShift[TraceT[F, ?]]): TraceT[F, Unit] = cs.shift
+
+  /**
+   * Lifts the non-strict, possibly impure expression computing a `TraceT[F, A]` into a `TraceT[F, A]`.
+   * The expression is suspended until the outer `TraceT` returned is run.
+   * @param t the non-strict expression computing `TraceT[F, A]` to lift into a `TraceT` context suspended
+   *   until the outer `TraceT` is run.
+   * @return a non-strict expression which computes `TraceT[F, A]` lifted into a `TraceT` in
+   *   a suspended state until the outer `TraceT` is run.
+   */
+  def suspend[F[_], A](t: => TraceT[F, A])(implicit F: Sync[F]): TraceT[F, A] =
+    toTraceT(F.delay(t)).flatMap(identity)
 
   /**
    * Lifts a program `F` which computes `A` into a `TraceT[F, A]` context.
@@ -328,6 +431,30 @@ object TraceT extends TraceTPolyFunctions with TraceTInstances {
    * @return a `TraceT[F, A]`
    */
   def toTraceT[F[_], A](fa: F[A]): TraceT[F, A] = TraceT { _ => fa }
+
+  /**
+   * Internal API — suspends the execution of `toEffect` in the `F` context.
+   *
+   * Used to build `TraceT[F, ?]` values for `F[_]` data types that implement `Monad`,
+   * in which case it is safer to trigger the `F[_]` context earlier.
+   *
+   * The basic requirement of `F` for callers of this function is `Functor`; however we are
+   * doing discrimination based on inheritance and if we detect a
+   * `Monad`, then we use it to trigger the `F[_]` context earlier.
+   *
+   * Triggering the `F[_]` context earlier is important to avoid stack
+   * safety issues for `F` monads that have stack safe implementations.
+   * For example `Eval` or `IO`. Without this the `Monad`
+   * instance is stack unsafe, even if the underlying `F` is stack safe.
+   *
+   * TODO: Look into a better construct such that we don't have to depend on the
+   * underlying `F` having a `Monad[F]` in order to make the overall `TraceT[F, ?]`
+   * stacksafe as its very brittle and non-type-safe.
+   */
+  private[dtrace] def suspendEffect[F[_], A](toEffect: TraceContext[F] => F[A])(implicit F: Functor[F]): TraceT[F, A] = F match {
+    case m: Monad[F] @unchecked => TraceT { tc => m.flatMap(m.pure(tc))(toEffect) }
+    case _ => TraceT(toEffect)
+  }
 }
 
 private[dtrace] sealed trait TraceTPolyFunctions {
@@ -341,22 +468,31 @@ private[dtrace] sealed trait TraceTPolyFunctions {
     }
 }
 
-private[dtrace] sealed trait TraceTInstances extends TraceTConcurrentEffectInstance with TraceTTimerInstance
+private[dtrace] sealed trait TraceTInstances extends TraceTConcurrentEffectInstance
+  with TraceTTimerInstance
+  with TraceTContextShiftInstance
+  with TraceTParallelInstances
 
 private[dtrace] sealed trait TraceTConcurrentEffectInstance extends TraceTConcurrentInstance with TraceTEffectInstance {
 
   implicit def concurrentEffectTraceTInstance[F[_]: ConcurrentEffect: TraceContext]: ConcurrentEffect[TraceT[F, ?]] = new ConcurrentEffectTraceT[F]
 
-  /** A `ConcurrentEffect[TraceT[F, ?]]` typeclass instance given an instance of `ConcurrentEffect[F]` and an instance of `TraceContext[F]`. */
+  /**
+   * A `ConcurrentEffect[TraceT[F, ?]]` typeclass instance given an instance of `ConcurrentEffect[F]` and an
+   * instance of `TraceContext[F]`.
+   * Note that the this typeclass and the `Effect[TraceT[F, ?]]` typeclass are the only instances requiring
+   * an implicit `TraceContext[F]` in scope.  This is because the tracing must be terminated and the underlying
+   * `F` effect exposed in order to ultimately derive a `SyncIO`, which the `runAsync` function of `Effect` and
+   * `runCancelable` function of `ConcurrentEffect` return, and in order to do that, a `TraceContext[F]` must be
+   * available.
+   */
   protected class ConcurrentEffectTraceT[F[_]](implicit F: ConcurrentEffect[F], TC: TraceContext[F]) extends ConcurrentTraceT[F] with ConcurrentEffect[TraceT[F, ?]] {
-    override def runCancelable[A](ta: TraceT[F, A])(cb: Either[Throwable, A] => IO[Unit]): IO[IO[Unit]] =
-      F.runCancelable(ta.tie(TC))(cb)
 
-    override def liftIO[A](ioa: IO[A]): TraceT[F, A] =
-      Concurrent.liftIO(ioa)(this)
+    override def runAsync[A](ta: TraceT[F, A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] =
+      F.runAsync(ta.trace(TC))(cb)
 
-    override def runAsync[A](ta: TraceT[F, A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] =
-      F.runAsync(ta.tie(TC))(cb)
+    override def runCancelable[A](ta: TraceT[F, A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[TraceT[F, ?]]] =
+      F.runCancelable(ta.trace(TC))(cb).map(TraceT.toTraceT(_))
 
     override def toString: String = "ConcurrentEffect[TraceT[F, ?]]"
   }
@@ -368,25 +504,22 @@ private[dtrace] sealed trait TraceTConcurrentInstance extends TraceTAsyncInstanc
 
   /** A `Concurrent[TraceT[F, ?]]` typeclass instance given an instance of `Concurrent[F]`. */
   protected class ConcurrentTraceT[F[_]](implicit F: Concurrent[F]) extends AsyncTraceT[F] with Concurrent[TraceT[F, ?]] {
-    override def cancelable[A](k: (Either[Throwable, A] => Unit) => IO[Unit]): TraceT[F, A] = TraceT.toTraceT(F.cancelable(k))
-    override def uncancelable[A](ta: TraceT[F, A]): TraceT[F, A] =
-      TraceT.ask[F].flatMap { tc => TraceT.toTraceT(F.uncancelable(ta.tie(tc))) }
-    override def onCancelRaiseError[A](ta: TraceT[F, A], e: Throwable): TraceT[F, A] =
-      TraceT.ask[F].flatMap { tc => TraceT.toTraceT(F.onCancelRaiseError(ta.tie(tc), e)) }
+    override def cancelable[A](k: (Either[Throwable, A] => Unit) => CancelToken[TraceT[F, ?]]): TraceT[F, A] =
+      TraceT.suspendEffect { tc => F.cancelable(k(_).toEffect(tc)) }
 
     override def start[A](ta: TraceT[F, A]): TraceT[F, Fiber[TraceT[F, ?], A]] =
-      TraceT.ask[F].flatMap { tc => TraceT.toTraceT(F.start(ta.tie(tc)) map toTraceTFiber) }
+      TraceT.suspendEffect { tc => F.start(ta.toEffect(tc)) map toTraceTFiber }
 
     override def racePair[A, B](ta: TraceT[F, A], tb: TraceT[F, B]): TraceT[F, Either[(A, Fiber[TraceT[F, ?], B]), (Fiber[TraceT[F, ?], A], B)]] =
-      TraceT.ask[F].flatMap { tc =>
-        TraceT.toTraceT(F.racePair(ta.tie(tc), tb.tie(tc)) map {
+      TraceT.suspendEffect { tc =>
+        F.racePair(ta.toEffect(tc), tb.toEffect(tc)) map {
           case Right(((fiba, b))) => Right(toTraceTFiber(fiba) -> b)
           case Left(((a, fibb))) => Left(a -> toTraceTFiber(fibb))
-        })
+        }
       }
 
     override def race[A, B](ta: TraceT[F, A], tb: TraceT[F, B]): TraceT[F, Either[A, B]] =
-      TraceT.ask[F].flatMap { tc => TraceT.toTraceT(F.race(ta.tie(tc), tb.tie(tc))) }
+      TraceT.suspendEffect { tc => F.race(ta.toEffect(tc), tb.toEffect(tc)) }
 
     override def liftIO[A](ioa: IO[A]): TraceT[F, A] = Concurrent.liftIO(ioa)(this)
 
@@ -403,11 +536,17 @@ private[dtrace] sealed trait TraceTEffectInstance extends TraceTAsyncInstance {
 
   implicit def effectTraceTInstance[F[_]: Effect: TraceContext]: Effect[TraceT[F, ?]] = new EffectTraceT[F]
 
-  /** A `Effect[TraceT[F, ?]]` typeclass instance given an instance of `Effect[F]` and an instance of `TraceContext[F]`. */
+  /**
+   * An `Effect[TraceT[F, ?]]` typeclass instance given an instance of `Effect[F]` and an instance of `TraceContext[F]`.
+   * Note that the this typeclass and the `ConcurrentEffect[TraceT[F, ?]]` typeclass are the only instances requiring an
+   * implicit `TraceContext[F]` in scope.  This is because the tracing must be terminated and the underlying `F` effect
+   * exposed in order to ultimately derive a `SyncIO`, which the `runAsync` function of `Effect` and `runCancelable`
+   * function of `ConcurrentEffect` return, and in order to do that, a `TraceContext[F]` must be available.
+   */
   protected class EffectTraceT[F[_]](implicit F: Effect[F], TC: TraceContext[F]) extends AsyncTraceT[F] with Effect[TraceT[F, ?]] {
 
-    override def runAsync[A](ta: TraceT[F, A])(cb: Either[Throwable, A] => IO[Unit]): IO[Unit] =
-      F.runAsync(ta.tie(TC))(cb)
+    override def runAsync[A](ta: TraceT[F, A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] =
+      F.runAsync(ta.trace(TC))(cb)
 
     override def toString: String = "Effect[TraceT[F, ?]]"
   }
@@ -420,6 +559,7 @@ private[dtrace] sealed trait TraceTAsyncInstance extends TraceTSyncInstance {
   /** A `Async[TraceT[F, ?]]` typeclass instance given an instance of `Async[F]`. */
   protected class AsyncTraceT[F[_]](implicit F: Async[F]) extends SyncTraceT[F] with Async[TraceT[F, ?]] {
     override def async[A](cb: (Either[Throwable, A] => Unit) => Unit): TraceT[F, A] = TraceT.async(cb)
+    override def asyncF[A](cb: (Either[Throwable, A] => Unit) => TraceT[F, Unit]): TraceT[F, A] = TraceT.asyncF(cb)
 
     override def liftIO[A](ioa: IO[A]): TraceT[F, A] =
       Async.liftIO(ioa)(this)
@@ -428,18 +568,31 @@ private[dtrace] sealed trait TraceTAsyncInstance extends TraceTSyncInstance {
   }
 }
 
-private[dtrace] sealed trait TraceTSyncInstance extends TraceTMonadErrorInstance {
+private[dtrace] sealed trait TraceTSyncInstance extends TraceTBracketInstance {
 
   implicit def syncTraceTInstance[F[_]: Sync]: Sync[TraceT[F, ?]] = new SyncTraceT[F]
 
-  /** A `Sync[TraceT[F, ?]]` typeclass instance given an instance of `Sync[F]` */
-  protected class SyncTraceT[F[_]: Sync] extends MonadErrorTraceT[F] with Sync[TraceT[F, ?]] {
+  /** A `Sync[TraceT[F, ?]]` typeclass instance given an instance of `Sync[F]`. */
+  protected class SyncTraceT[F[_]: Sync] extends BracketTraceT[F] with Sync[TraceT[F, ?]] {
 
     override def suspend[A](ta: => TraceT[F, A]): TraceT[F, A] = TraceT.suspend(ta)
 
-    override def delay[A](a: => A): TraceT[F, A] = TraceT.delay(a)
-
     override def toString: String = "Sync[TraceT[F, ?]]"
+  }
+}
+
+private[dtrace] sealed trait TraceTBracketInstance extends TraceTMonadErrorInstance {
+
+  implicit def bracketTraceTInstance[F[_]](implicit F: Bracket[F, Throwable]): Bracket[TraceT[F, ?], Throwable] =
+    new BracketTraceT[F]
+
+  /** A `Bracket[TraceT[F, ?], Throwable]` typeclass instance given an instance of `Bracket[F, Throwable]`. */
+  protected class BracketTraceT[F[_]](implicit F: Bracket[F, Throwable]) extends MonadErrorTraceT[F] with Bracket[TraceT[F, ?], Throwable] {
+
+    override def bracketCase[A, B](acquire: TraceT[F, A])(use: A => TraceT[F, B])(release: (A, ExitCase[Throwable]) => TraceT[F, Unit]): TraceT[F, B] =
+      acquire.bracketCase(use)(release)
+
+    override def toString: String = "Bracket[TraceT[F, ?], Throwable]"
   }
 }
 
@@ -465,7 +618,7 @@ private[dtrace] sealed trait TraceTMonadInstance {
   implicit def monadTraceTInstance[F[_]: Monad]: Monad[TraceT[F, ?]] = new MonadTraceT[F]
 
   /** A `Monad[TraceT[F, ?]]` typeclass instance given an instance of `Monad[F, Throwable]` */
-  protected class MonadTraceT[F[_]: Monad] extends Monad[TraceT[F, ?]] {
+  protected class MonadTraceT[F[_]](implicit F: Monad[F]) extends Monad[TraceT[F, ?]] {
 
     override def pure[A](a: A): TraceT[F, A] = TraceT.pure(a)
 
@@ -474,10 +627,7 @@ private[dtrace] sealed trait TraceTMonadInstance {
     override def flatMap[A, B](a: TraceT[F, A])(f: A => TraceT[F, B]): TraceT[F, B] = a flatMap f
 
     override def tailRecM[A, B](a: A)(f: A => TraceT[F, Either[A, B]]): TraceT[F, B] =
-      f(a).flatMap {
-        case Left(a) => tailRecM(a)(f)
-        case Right(b) => pure(b)
-      }
+      TraceT.suspendEffect { tc => F.tailRecM(a)(f(_).toEffect(tc)) }
 
     override def toString: String = "Monad[TraceT[F, ?]]"
   }
@@ -490,14 +640,108 @@ private[dtrace] sealed trait TraceTTimerInstance {
   /** A `Timer[TraceT[F, ?]]` typeclass instance given an instance of `Timer[F]. */
   protected class TraceTTimer[F[_]](implicit F: Timer[F]) extends Timer[TraceT[F, ?]] {
 
-    override def clockRealTime(unit: TimeUnit): TraceT[F, Long] = TraceT.toTraceT(F.clockRealTime(unit))
-
-    override def clockMonotonic(unit: TimeUnit): TraceT[F, Long] = TraceT.toTraceT(F.clockMonotonic(unit))
-
+    override val clock: Clock[TraceT[F, ?]] = new Clock[TraceT[F, ?]] {
+      def realTime(unit: TimeUnit): TraceT[F, Long] = TraceT.toTraceT(F.clock.realTime(unit))
+      def monotonic(unit: TimeUnit): TraceT[F, Long] = TraceT.toTraceT(F.clock.monotonic(unit))
+    }
     override def sleep(duration: FiniteDuration): TraceT[F, Unit] = TraceT.toTraceT(F.sleep(duration))
 
-    override def shift: TraceT[F, Unit] = TraceT.toTraceT(F.shift)
-
     override def toString: String = "Timer[TraceT[F, ?]]"
+  }
+}
+
+private[dtrace] sealed trait TraceTContextShiftInstance {
+  /**
+   * Generates a `ContextShift[TraceT[F, ?]` in implicit scope, given a `Monad[F]` and `ContextShift[F]` in implicit scope.
+   */
+  implicit def contextShiftInstance[F[_]: Monad](implicit cs: ContextShift[F]): ContextShift[TraceT[F, ?]] = new ContextShift[TraceT[F, ?]] {
+    def shift: TraceT[F, Unit] = TraceT.toTraceT(cs.shift)
+    def evalOn[A](ec: ExecutionContext)(f: TraceT[F, A]): TraceT[F, A] =
+      TraceT.suspendEffect { tc => cs.evalOn(ec)(f.toEffect(tc)) }
+  }
+}
+
+private[dtrace] sealed trait TraceTParallelInstances extends TraceTParallelInstance {
+  implicit def ioParApplicative(implicit cs: ContextShift[IO], p: Parallel[IO, IO.Par]): Applicative[TraceT[IO.Par, ?]] =
+    implicitly[Parallel[TraceT[IO, ?], TraceT[IO.Par, ?]]].applicative
+}
+
+private[dtrace] sealed trait TraceTParallelInstance extends TraceTNonEmptyParallelInstance {
+
+  implicit def parallelTraceTInstance[M[_]: Monad, F[_]: Applicative](implicit P: Parallel[M, F]): Parallel[TraceT[M, ?], TraceT[F, ?]] =
+    new ParallelTraceT[M, F]
+
+  /** A `Parallel[TraceT[M, ?], TraceT[F, ?]` typeclass instance given an instance of `Parallel[M, F]` */
+  protected class ParallelTraceT[M[_]: Monad, F[_]: Applicative](implicit P: Parallel[M, F]) extends NonEmptyParallelTraceT[M, F] with Parallel[TraceT[M, ?], TraceT[F, ?]] {
+    override def applicative: Applicative[TraceT[F, ?]] = new Applicative[TraceT[F, ?]] {
+      override def map[A, B](ta: TraceT[F, A])(f: A => B): TraceT[F, B] = TraceT.suspendEffect { tc =>
+        P.applicative.map(ta.toEffect(tc))(f)
+      }
+      override def pure[A](a: A): TraceT[F, A] = TraceT.toTraceT(P.applicative.pure(a))
+      override def ap[A, B](tab: TraceT[F, A => B])(ta: TraceT[F, A]): TraceT[F, B] = TraceT.suspendEffect { tc =>
+        P.applicative.ap(tab.toEffect(tc))(ta.toEffect(tc))
+      }
+      override def toString: String = "ParApplicative[TraceT[F, ?]]"
+    }
+    override def monad: Monad[TraceT[M, ?]] = new Monad[TraceT[M, ?]] {
+      override def pure[A](a: A): TraceT[M, A] = TraceT.toTraceT(P.monad.pure(a))
+
+      override def map[A, B](ta: TraceT[M, A])(f: A => B): TraceT[M, B] = TraceT.suspendEffect { tc =>
+        P.monad.map(ta.toEffect(tc))(f)
+      }
+
+      override def flatMap[A, B](ta: TraceT[M, A])(f: A => TraceT[M, B]): TraceT[M, B] = TraceT.suspendEffect { tc =>
+        P.monad.flatMap(ta.toEffect(tc))(f(_).toEffect(tc))
+      }
+
+      override def tailRecM[A, B](a: A)(f: A => TraceT[M, Either[A, B]]): TraceT[M, B] =
+        TraceT.suspendEffect { tc => P.monad.tailRecM(a)(f(_).toEffect(tc)) }
+
+      override def toString: String = "ParMonad[TraceT[M, ?]]"
+    }
+  }
+}
+
+private[dtrace] sealed trait TraceTNonEmptyParallelInstance {
+
+  implicit def neParallelTraceTInstance[M[_]: FlatMap, F[_]: Apply](implicit P: NonEmptyParallel[M, F]): NonEmptyParallel[TraceT[M, ?], TraceT[F, ?]] =
+    new NonEmptyParallelTraceT[M, F]
+
+  /** A `NonEmptyParallel[TraceT[M, ?], TraceT[F, ?]` typeclass instance given an instance of `NonEmptyParallel[M, F]` */
+  protected class NonEmptyParallelTraceT[M[_]: FlatMap, F[_]: Apply](implicit P: NonEmptyParallel[M, F]) extends NonEmptyParallel[TraceT[M, ?], TraceT[F, ?]] {
+    def apply: Apply[TraceT[F, ?]] = new Apply[TraceT[F, ?]] {
+      override def ap[A, B](tab: TraceT[F, A => B])(ta: TraceT[F, A]): TraceT[F, B] = TraceT.suspendEffect { tc =>
+        P.apply.ap(tab.toEffect(tc))(ta.toEffect(tc))
+      }
+      override def map[A, B](ta: TraceT[F, A])(f: A => B): TraceT[F, B] = TraceT.suspendEffect { tc =>
+        P.apply.map(ta.toEffect(tc))(f)
+      }
+      override def toString: String = "ParApply[TraceT[F, ?]]"
+    }
+    def flatMap: FlatMap[TraceT[M, ?]] = new FlatMap[TraceT[M, ?]] {
+      override def flatMap[A, B](ta: TraceT[M, A])(f: A => TraceT[M, B]): TraceT[M, B] = TraceT.suspendEffect { tc =>
+        P.flatMap.flatMap(ta.toEffect(tc))(f(_).toEffect(tc))
+      }
+      override def ap[A, B](tab: TraceT[M, A => B])(ta: TraceT[M, A]): TraceT[M, B] = TraceT.suspendEffect { tc =>
+        P.flatMap.ap(tab.toEffect(tc))(ta.toEffect(tc))
+      }
+      override def map[A, B](ta: TraceT[M, A])(f: A => B): TraceT[M, B] = TraceT.suspendEffect { tc =>
+        P.flatMap.map(ta.toEffect(tc))(f)
+      }
+      override def tailRecM[A, B](a: A)(f: A => TraceT[M, Either[A, B]]): TraceT[M, B] =
+        TraceT.suspendEffect { tc => P.flatMap.tailRecM(a)(f(_).toEffect(tc)) }
+
+      override def toString: String = "ParFlatMap[TraceT[M, ?]]"
+    }
+    def sequential: TraceT[F, ?] ~> TraceT[M, ?] = new (TraceT[F, ?] ~> TraceT[M, ?]) {
+      def apply[A](tfa: TraceT[F, A]): TraceT[M, A] = TraceT.suspendEffect[M, A] { tc =>
+        P.sequential(tfa.toEffect(translate(tc, P.parallel)))
+      }
+    }
+    def parallel: TraceT[M, ?] ~> TraceT[F, ?] = new (TraceT[M, ?] ~> TraceT[F, ?]) {
+      def apply[A](tma: TraceT[M, A]): TraceT[F, A] = TraceT.suspendEffect[F, A] { tc =>
+        P.parallel(tma.toEffect(translate(tc, P.sequential)))
+      }
+    }
   }
 }

--- a/core/src/test/scala/com/ccadllc/cedi/dtrace/TestData.scala
+++ b/core/src/test/scala/com/ccadllc/cedi/dtrace/TestData.scala
@@ -15,7 +15,8 @@
  */
 package com.ccadllc.cedi.dtrace
 
-import java.time.Instant
+import cats.effect._
+
 import java.util.UUID
 
 import scala.concurrent.duration._
@@ -42,14 +43,13 @@ trait TestData {
   protected val quarterlySalesTotalNoteValue: Note.DoubleValue = Note.DoubleValue(95.6)
   protected val quarterlySalesTotalNote: Note = Note(Note.Name("quarterlySalesTotal"), Some(quarterlySalesTotalNoteValue))
   protected val quarterlySalesCalculationSpanNotes: Vector[Note] = Vector[Note](
-    quarterlySalesUnitsNote, quarterlySalesGoalReachedNote, salesRegionNote, quarterlySalesTotalNote
-  )
+    quarterlySalesUnitsNote, quarterlySalesGoalReachedNote, salesRegionNote, quarterlySalesTotalNote)
+  protected val quarterlySalesCalculationTimer: TraceSystem.Timer[IO] = TraceSystem.realTimeTimer[IO]
   protected val quarterlySalesCalculationSpan: Span = Span(
     quarterlySalesCalculationSpanId,
     Span.Name("Calculate Quarterly Sales"),
-    Instant.now,
+    quarterlySalesCalculationTimer.time.unsafeRunSync,
     None,
     15000.microseconds,
-    quarterlySalesCalculationSpanNotes
-  )
+    quarterlySalesCalculationSpanNotes)
 }

--- a/core/src/test/scala/com/ccadllc/cedi/dtrace/TestEmitterRecordingTest.scala
+++ b/core/src/test/scala/com/ccadllc/cedi/dtrace/TestEmitterRecordingTest.scala
@@ -23,15 +23,17 @@ class TestEmitterRecordingTest extends WordSpec with BeforeAndAfterEach with Mat
   "the distributed trace recording mechanism for emitting to a test string emitter" should {
     "support recording a successful current tracing span which is the root span containing same parent and current span IDs" in {
       val testEmitter = new TestEmitter[IO]
-      val salesManagementSystem = TraceSystem(testSystemMetadata, testEmitter)
-      val spanRoot = Span.root[IO](Span.Name("calculate-quarterly-sales")).unsafeRunSync
+      val testTimer = TraceSystem.realTimeTimer[IO]
+      val salesManagementSystem = TraceSystem(testSystemMetadata, testEmitter, testTimer)
+      val spanRoot = Span.root(testTimer, Span.Name("calculate-quarterly-sales")).unsafeRunSync
       IO(Thread.sleep(5L)).toTraceT.trace(TraceContext(spanRoot, salesManagementSystem)).unsafeRunSync
       testEmitter.cache.containingAll(spanId(spanRoot.spanId.spanId), parentSpanId(spanRoot.spanId.spanId), spanName(spanRoot.spanName)) should have size (1)
     }
     "support recording a successful new tracing span with new span ID and name" in {
       val testEmitter = new TestEmitter[IO]
-      val salesManagementSystem = TraceSystem(testSystemMetadata, testEmitter)
-      val spanRoot = Span.root[IO](Span.Name("calculate-quarterly-sales")).unsafeRunSync
+      val testTimer = TraceSystem.realTimeTimer[IO]
+      val salesManagementSystem = TraceSystem(testSystemMetadata, testEmitter, testTimer)
+      val spanRoot = Span.root(testTimer, Span.Name("calculate-quarterly-sales")).unsafeRunSync
       val calcPhillySalesSpanName = Span.Name("calculate-sales-for-philadelphia")
       IO(Thread.sleep(5L)).newSpan(calcPhillySalesSpanName).trace(TraceContext(spanRoot, salesManagementSystem)).unsafeRunSync
       testEmitter.cache.containingAll(parentSpanId(spanRoot.spanId.spanId), spanName(calcPhillySalesSpanName)) should have size (1)
@@ -51,9 +53,10 @@ class TestEmitterRecordingTest extends WordSpec with BeforeAndAfterEach with Mat
     }
     "support recording nested spans" in {
       val testEmitter = new TestEmitter[IO]
-      val salesManagementSystem = TraceSystem(testSystemMetadata, testEmitter)
+      val testTimer = TraceSystem.realTimeTimer[IO]
+      val salesManagementSystem = TraceSystem(testSystemMetadata, testEmitter, testTimer)
       val spanRootName = Span.Name("calculate-quarterly-sales-update")
-      val spanRoot = Span.root[IO](spanRootName).unsafeRunSync
+      val spanRoot = Span.root(testTimer, spanRootName).unsafeRunSync
       val requestUpdatedSalesFiguresSpanName = Span.Name("request-updated-sales-figures")
       val generateUpdatedSalesFiguresSpanName = Span.Name("generate-updated-sales-figures")
       def generateSalesFigures: TraceIO[Unit] = for {
@@ -79,8 +82,9 @@ class TestEmitterRecordingTest extends WordSpec with BeforeAndAfterEach with Mat
 
   private def assertChildSpanRecordedWithNote(note: Note): Unit = {
     val testEmitter = new TestEmitter[IO]
-    val salesManagementSystem = TraceSystem(testSystemMetadata, testEmitter)
-    val spanRoot = Span.root[IO](Span.Name("calculate-quarterly-sales-updates")).unsafeRunSync
+    val testTimer = TraceSystem.realTimeTimer[IO]
+    val salesManagementSystem = TraceSystem(testSystemMetadata, testEmitter, testTimer)
+    val spanRoot = Span.root(testTimer, Span.Name("calculate-quarterly-sales-updates")).unsafeRunSync
     val calcPhillySalesSpanName = Span.Name("calculate-updated-sales-for-philly")
     IO {
       Thread.sleep(5L)

--- a/core/src/test/scala/com/ccadllc/cedi/dtrace/TypeclassLawTests.scala
+++ b/core/src/test/scala/com/ccadllc/cedi/dtrace/TypeclassLawTests.scala
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2018 Combined Conditional Access Development, LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ccadllc.cedi.dtrace
+
+import cats._
+
+import cats.effect._
+import cats.effect.laws.discipline._
+import cats.effect.laws.discipline.arbitrary._
+import cats.effect.laws.util._
+
+import cats.implicits._
+
+import cats.kernel.Eq
+
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline._
+
+import java.io.{ ByteArrayOutputStream, PrintStream }
+import java.nio.charset.Charset
+
+import org.scalactic.source
+import org.scalacheck._
+import org.scalatest.prop.Checkers
+import org.scalatest.{ FunSuite, Matchers, Tag }
+
+import org.typelevel.discipline.Laws
+import org.typelevel.discipline.scalatest.Discipline
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.util.Success
+import scala.util.control.NonFatal
+
+class TypeclassLawTests extends FunSuite with Matchers with Checkers with Discipline with TestInstances with TestData {
+
+  private implicit def eqTraceIO[A](implicit A: Eq[A], testC: TestContext): Eq[TraceIO[A]] =
+    new Eq[TraceIO[A]] {
+      def eqv(x: TraceIO[A], y: TraceIO[A]): Boolean =
+        eqIO[A].eqv(x.toEffect(tc), y.toEffect(tc))
+    }
+
+  private implicit def eqTraceIOPar[A](implicit A: Eq[A], testC: TestContext): Eq[TraceIO.Par[A]] = {
+    implicit val cs = IO.contextShift(ExecutionContext.global)
+    new Eq[TraceIO.Par[A]] {
+      def eqv(x: TraceIO.Par[A], y: TraceIO.Par[A]): Boolean =
+        eqTraceIO[A].eqv(TraceIO.Par.unwrap(x), TraceIO.Par.unwrap(y))
+    }
+  }
+
+  private implicit def catsConcurrentEffectLawsArbitraryForTraceIO[A: Arbitrary: Cogen]: Arbitrary[TraceIO[A]] =
+    Arbitrary(catsEffectLawsArbitraryForIO[A].arbitrary map TraceIO.toTraceIO)
+
+  private implicit def catsEffectLawsArbitraryForTraceIOParallel[A: Arbitrary: Cogen]: Arbitrary[TraceIO.Par[A]] =
+    Arbitrary(catsEffectLawsArbitraryForIOParallel[A].arbitrary map TraceIO.Par.apply)
+
+  private val tc: TraceContext[IO] = {
+    val timer = TraceSystem.realTimeTimer[IO]
+    TraceContext(
+      Span.root(timer, Span.Name("calculate-quarterly-sales")).unsafeRunSync,
+      TraceSystem(testSystemMetadata, new TestEmitter[IO], timer))
+  }
+
+  checkAllAsync("TraceIO", implicit testC => {
+    implicit val csIo = testC.contextShift[IO]
+    implicit val tcInstance = tc
+    ConcurrentEffectTests[TraceIO].concurrentEffect[Int, Int, Int]
+  })
+
+  checkAllAsync("TraceIO.Par", implicit testC => {
+    implicit val cs = testC.contextShift[IO]
+    ApplicativeTests[TraceIO.Par].applicative[Int, Int, Int]
+  })
+
+  checkAllAsync("TraceIO", implicit testC => {
+    implicit val cs = testC.contextShift[IO]
+    ParallelTests[TraceIO, TraceIO.Par].parallel[Int, Int]
+  })
+
+  testAsync("TraceIO.Par's applicative instance is different") { implicit testC =>
+    implicit val cs = testC.contextShift[IO]
+    implicitly[Applicative[TraceIO]] shouldNot be(implicitly[Applicative[TraceIO.Par]])
+    ()
+  }
+
+  test("Timer[TraceIO].clock.realTime") {
+    implicit val ec = ExecutionContext.global
+    implicit val iot = IO.timer(ec)
+    val time = System.currentTimeMillis
+    val tio = implicitly[Timer[TraceIO]].clock.realTime(MILLISECONDS)
+    for (t2 <- tio.trace(tc).unsafeToFuture()) yield {
+      time should be > 0L
+      time should be <= t2
+    }
+  }
+
+  test("Timer[TraceIO].clock.monotonic") {
+    implicit val ec = ExecutionContext.global
+    implicit val iot = IO.timer(ec)
+    val time = System.nanoTime
+    val tio = implicitly[Timer[TraceIO]].clock.monotonic(NANOSECONDS)
+
+    for (t2 <- tio.trace(tc).unsafeToFuture()) yield {
+      time should be > 0L
+      time should be <= t2
+    }
+  }
+
+  test("Timer[TraceIO].sleep(10.ms)") {
+    implicit val ec = ExecutionContext.global
+    implicit val iot = IO.timer(ec)
+    val t = implicitly[Timer[TraceIO]]
+    val tio = for {
+      start <- t.clock.monotonic(MILLISECONDS)
+      _ <- t.sleep(10.millis)
+      end <- t.clock.monotonic(MILLISECONDS)
+    } yield {
+      end - start
+    }
+
+    for (r <- tio.trace(tc).unsafeToFuture()) yield {
+      r should be > 0L
+    }
+  }
+
+  test("Timer[TraceIO].sleep(negative)") {
+    implicit val ec = ExecutionContext.global
+    implicit val iot = IO.timer(ec)
+    val tio = implicitly[Timer[TraceIO]].sleep(-10.seconds).map(_ => 10)
+
+    for (r <- tio.trace(tc).unsafeToFuture()) yield {
+      r shouldBe 10L
+    }
+  }
+
+  testAsync("ContextShift[TraceIO].shift") { testC =>
+    implicit val cs = TraceIO.contextShift(testC)
+    val f = cs.shift.trace(tc).unsafeToFuture()
+    f.value shouldBe 'empty
+    testC.tick()
+    f.value shouldBe Some(Success(()))
+    ()
+  }
+
+  testAsync("ContextShift[TraceIO].evalOn") { testC =>
+    implicit val cs = TraceIO.contextShift(testC)
+    val testC2 = TestContext()
+    val f = cs.evalOn(testC2)(TraceIO(1)).trace(tc).unsafeToFuture()
+    f.value shouldBe 'empty
+    testC.tick()
+    f.value shouldBe 'empty
+    testC2.tick()
+    f.value shouldBe 'empty
+    testC.tick()
+    f.value shouldBe Some(Success(1))
+    ()
+  }
+
+  private def checkAllAsync(name: String, f: TestContext => Laws#RuleSet): Unit = {
+    val testC = TestContext()
+    val ruleSet = f(testC)
+    for ((id, prop) <- ruleSet.all.properties)
+      test(s"$name.$id") { silenceSystemErr(check(prop)) }
+  }
+
+  private def silenceSystemErr[A](thunk: => A): A = synchronized {
+    val oldErr = System.err
+    val outStream = new ByteArrayOutputStream()
+    val silentErr = new PrintStream(outStream)
+    System.setErr(silentErr)
+    try {
+      val r = thunk
+      System.setErr(oldErr)
+      r
+    } catch {
+      case NonFatal(e) =>
+        System.setErr(oldErr)
+        val out = outStream.toString(Charset.defaultCharset.displayName)
+        if (out.nonEmpty) oldErr.println(out)
+        silentErr.close()
+        throw e
+    }
+  }
+  private def testAsync[A](name: String, tags: Tag*)(f: TestContext => Unit)(implicit pos: source.Position): Unit = {
+    test(name, tags: _*)(silenceSystemErr(f(TestContext())))(pos)
+  }
+}

--- a/http4s/src/main/scala/com/ccadllc/cedi/dtrace/interop/http4s/server/server.scala
+++ b/http4s/src/main/scala/com/ccadllc/cedi/dtrace/interop/http4s/server/server.scala
@@ -21,26 +21,10 @@ import cats.effect.Sync
 import cats.implicits._
 
 import org.http4s.{ Header => H4sHeader, _ }
-import org.http4s.parser.HttpHeaderParser
-import org.http4s.util.CaseInsensitiveString
 
 import scala.language.higherKinds
 
 package object server {
-  /**
-   * This function drops the parser for the built-in `http4s` `X-B3-Trace-Id` header since it only successfully parses 64 bit
-   * values, failing on 128 bit values and with cedi dtrace, the 128 bit value will be produced and are preferred
-   * to consume in order to represent traces uniquely in a distributed environment.  Once `http4s` updates the parser to handle
-   * 128 bit values, this can be removed.  This should be invoked in your initialization code.
-   * Once [[https://github.com/http4s/http4s/issues/1859 this issue]] is resolved, this can be removed.
-   *
-   * @param F - an instance of `cats.effect.Sync` for the effect type `F`, used to delay the side effecting action.
-   * @tparam F - a type constructor representing the effect in which to execute the side-effecting action to drop the
-   *   X-B3 Trace ID header from the global header parser registry.
-   */
-  def dropBuiltInXb3Headers[F[_]](implicit F: Sync[F]): F[Unit] =
-    F.delay(HttpHeaderParser.dropParser(CaseInsensitiveString("X-B3-TRACEID"))).void
-
   /**
    * This function can be used to execute a traced action within an `HttpService[F]` with
    * the [[TraceContext]] of `F` possibly derived from HTTP headers, given instances of `cats.effect.Sync[F]`, [[HeaderCodec]],
@@ -78,7 +62,7 @@ package object server {
    */
   def tracedAction[F[_], A](req: Request[F], spanName: Span.Name, notes: Note*)(action: TraceT[F, A])(implicit codec: HeaderCodec, F: Sync[F], ts: TraceSystem[F]): F[A] = codec.decode(fromHttp4s(req.headers.toList)) match {
     case Right(spanIdMaybe) =>
-      spanIdMaybe.fold(Span.root[F](spanName, notes: _*)) { Span.newChild[F](_, spanName, notes: _*) }.flatMap { span =>
+      spanIdMaybe.fold(Span.root[F](ts.timer, spanName, notes: _*)) { Span.newChild[F](ts.timer, _, spanName, notes: _*) }.flatMap { span =>
         action.trace(TraceContext(span, ts))
       }
     case Left(errDetail) => F.raiseError[A](errDetail)

--- a/logging/src/main/scala/com/ccadllc/cedi/dtrace/logging/json.scala
+++ b/logging/src/main/scala/com/ccadllc/cedi/dtrace/logging/json.scala
@@ -19,7 +19,6 @@ package logging
 import scala.language.higherKinds
 
 import io.circe._
-import io.circe.java8.time._
 import io.circe.syntax._
 
 /**

--- a/logging/src/test/scala/com/ccadllc/cedi/dtrace/logging/JsonLogEncodingTest.scala
+++ b/logging/src/test/scala/com/ccadllc/cedi/dtrace/logging/JsonLogEncodingTest.scala
@@ -21,7 +21,6 @@ import scala.language.higherKinds
 import cats.effect.{ IO, Sync }
 
 import io.circe._
-import io.circe.java8.time._
 import io.circe.syntax._
 
 import org.scalacheck.Arbitrary

--- a/logging/src/test/scala/com/ccadllc/cedi/dtrace/logging/RecordingTestSupport.scala
+++ b/logging/src/test/scala/com/ccadllc/cedi/dtrace/logging/RecordingTestSupport.scala
@@ -47,14 +47,14 @@ trait RecordingTestSupport extends TestSupport with BeforeAndAfterEach {
   protected def spanNote(note: Note): String
 
   protected def assertRootSpanRecorded(): Unit = {
-    val spanRoot = Span.root[IO](Span.Name("calculate-quarterly-sales")).unsafeRunSync
+    val spanRoot = Span.root[IO](quarterlySalesCalculationTimer, Span.Name("calculate-quarterly-sales")).unsafeRunSync
     IO(Thread.sleep(5L)).toTraceT.trace(TraceContext(spanRoot, salesManagementSystem)).unsafeRunSync
     LogEmitterTestCache.containingAll(spanId(spanRoot.spanId.spanId), parentSpanId(spanRoot.spanId.spanId), spanName(spanRoot.spanName)) should have size (1)
     ()
   }
 
   protected def assertChildSpanRecorded(): Unit = {
-    val spanRoot = Span.root[IO](Span.Name("calculate-quarterly-sales")).unsafeRunSync
+    val spanRoot = Span.root[IO](quarterlySalesCalculationTimer, Span.Name("calculate-quarterly-sales")).unsafeRunSync
     val retrieveExistingSalesSpanName = Span.Name("retrieve-existing-sales")
     IO(Thread.sleep(5L)).newSpan(retrieveExistingSalesSpanName).trace(TraceContext(spanRoot, salesManagementSystem)).unsafeRunSync
     LogEmitterTestCache.containingAll(parentSpanId(spanRoot.spanId.spanId), spanName(retrieveExistingSalesSpanName)) should have size (1)
@@ -63,7 +63,7 @@ trait RecordingTestSupport extends TestSupport with BeforeAndAfterEach {
   }
 
   protected def assertChildSpanRecordedWithNote(note: Note): Unit = {
-    val spanRoot = Span.root[IO](Span.Name("calculate-quarterly-sales")).unsafeRunSync
+    val spanRoot = Span.root[IO](quarterlySalesCalculationTimer, Span.Name("calculate-quarterly-sales")).unsafeRunSync
     val retrieveExistingSalesSpanName = Span.Name("retrieve-existing-sales")
     IO(Thread.sleep(5L)).newSpan(retrieveExistingSalesSpanName, note).trace(TraceContext(spanRoot, salesManagementSystem)).unsafeRunSync
     val entriesWithNote = LogEmitterTestCache.containingAll(parentSpanId(spanRoot.spanId.spanId), spanName(retrieveExistingSalesSpanName), spanNote(note))
@@ -75,7 +75,7 @@ trait RecordingTestSupport extends TestSupport with BeforeAndAfterEach {
 
   protected def assertNestedSpansRecorded(): Unit = {
     val spanRootName = Span.Name("calculate-quarterly-sales")
-    val spanRoot = Span.root[IO](spanRootName).unsafeRunSync
+    val spanRoot = Span.root[IO](quarterlySalesCalculationTimer, spanRootName).unsafeRunSync
     val requestExistingSalesFiguresSpanName = Span.Name("request-existing-sales-figures")
     val generateNewSalesFiguresSpanName = Span.Name("generate-new-sales-figures")
     def calculateSales: TraceIO[Unit] = for {

--- a/logging/src/test/scala/com/ccadllc/cedi/dtrace/logging/TestSupport.scala
+++ b/logging/src/test/scala/com/ccadllc/cedi/dtrace/logging/TestSupport.scala
@@ -36,7 +36,7 @@ trait TestSupport extends WordSpecLike with Matchers with GeneratorDrivenPropert
   override def testEmitter[F[_]: Sync]: TraceSystem.Emitter[F] = new LogEmitter[F]
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 100)
-  val salesManagementSystem = TraceSystem(testSystemMetadata, testEmitter[IO])
+  val salesManagementSystem = TraceSystem(testSystemMetadata, testEmitter[IO], TraceSystem.realTimeTimer[IO])
   val calculateQuarterlySalesTraceContext = TraceContext(quarterlySalesCalculationSpan, salesManagementSystem)
 
   def encodeArbitraryJson[A: Arbitrary](implicit encoder: Lazy[Encoder[A]]): Unit = {

--- a/logstash/src/main/scala/com/ccadllc/cedi/dtrace/logstash/LogstashLogbackEmitter.scala
+++ b/logstash/src/main/scala/com/ccadllc/cedi/dtrace/logstash/LogstashLogbackEmitter.scala
@@ -17,7 +17,7 @@ package com.ccadllc.cedi.dtrace
 package logstash
 
 import cats.effect.Sync
-import java.time.format.DateTimeFormatter
+import cats.implicits._
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers._
 import org.slf4j.LoggerFactory
@@ -38,7 +38,7 @@ final class LogstashLogbackEmitter[F[_]](implicit F: Sync[F]) extends TraceSyste
           and[LogstashMarker](append("span-id", s.spanId.spanId)).
           and[LogstashMarker](append("parent-id", s.spanId.parentSpanId)).
           and[LogstashMarker](append("span-name", s.spanName.value)).
-          and[LogstashMarker](append("start-time", DateTimeFormatter.ISO_INSTANT.format(s.startTime))).
+          and[LogstashMarker](append("start-time", s.startTime.show)).
           and[LogstashMarker](append("span-success", s.failure.isEmpty)).
           and[LogstashMarker](append("failure-detail", s.failure.map(_.render).orNull)).
           and[LogstashMarker](append("span-duration", s.duration.toMicros)).

--- a/money/src/main/scala/com/ccadllc/cedi/dtrace/interop/money/MoneyHeaderCodec.scala
+++ b/money/src/main/scala/com/ccadllc/cedi/dtrace/interop/money/MoneyHeaderCodec.scala
@@ -26,15 +26,14 @@ import scala.util.matching.Regex
 import MoneyHeaderCodec._
 
 /**
- * Implements the [[HeaderCodec]] trait, providing for the encoding and decoding of
- * `Money`-style tracing HTTP headers into and from a [[SpanId]] respectively.
+ * Implements the `HeaderCodec` trait, providing for the encoding and decoding of
+ * `Money`-style tracing HTTP headers into and from a `SpanId` respectively.
  */
 class MoneyHeaderCodec extends HeaderCodec {
 
   override def encode(spanId: SpanId): List[Header] = {
     val headerValue = Header.Value(
-      s"$TraceIdHeader=${spanId.traceId};$ParentIdHeader=${spanId.parentSpanId};$SpanIdHeader=${spanId.spanId}"
-    )
+      s"$TraceIdHeader=${spanId.traceId};$ParentIdHeader=${spanId.parentSpanId};$SpanIdHeader=${spanId.spanId}")
     List(Header(HeaderName, headerValue))
   }
 

--- a/money/src/test/scala/com/ccadllc/cedi/dtrace/interop/money/MoneyHeaderCodecTest.scala
+++ b/money/src/test/scala/com/ccadllc/cedi/dtrace/interop/money/MoneyHeaderCodecTest.scala
@@ -35,8 +35,7 @@ class MoneyHeaderCodecTest extends WordSpec with Matchers with GeneratorDrivenPr
         val expectedSpanId = SpanId(traceIdValue, parentSpanIdValue, spanIdValue)
         val header = Header(
           HeaderName,
-          Header.Value(s"$TraceIdHeader=$traceIdValue;$ParentIdHeader=$parentSpanIdValue;$SpanIdHeader=$spanIdValue")
-        )
+          Header.Value(s"$TraceIdHeader=$traceIdValue;$ParentIdHeader=$parentSpanIdValue;$SpanIdHeader=$spanIdValue"))
         val errorOrSpanId = headerCodec.decode(List(header))
         errorOrSpanId shouldBe Right(Some(expectedSpanId))
       }
@@ -45,8 +44,7 @@ class MoneyHeaderCodecTest extends WordSpec with Matchers with GeneratorDrivenPr
       forAll { (traceIdValue: UUID, parentSpanIdValue: Long, spanIdValue: Long) =>
         val expectedHeader = Header(
           HeaderName,
-          Header.Value(s"$TraceIdHeader=$traceIdValue;$ParentIdHeader=$parentSpanIdValue;$SpanIdHeader=$spanIdValue")
-        )
+          Header.Value(s"$TraceIdHeader=$traceIdValue;$ParentIdHeader=$parentSpanIdValue;$SpanIdHeader=$spanIdValue"))
         val spanId = SpanId(traceIdValue, parentSpanIdValue, spanIdValue)
         val headers = headerCodec.encode(spanId)
         headers shouldBe List(expectedHeader)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.1.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers += Resolver.sonatypeRepo("public")
 
-addSbtPlugin("com.ccadllc.cedi" %% "build" % "1.1.0-SNAPSHOT")
+addSbtPlugin("com.ccadllc.cedi" %% "build" % "1.1.0")
 
 addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
 resolvers += Resolver.sonatypeRepo("public")
 
-addSbtPlugin("com.ccadllc.cedi" %% "build" % "1.0.4")
+addSbtPlugin("com.ccadllc.cedi" %% "build" % "1.1.0-SNAPSHOT")
 
-addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.0")
-
+addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")

--- a/readme/src/main/tut/README.md
+++ b/readme/src/main/tut/README.md
@@ -6,7 +6,7 @@ Quick links:
 - [Examples of use](#usage)
 - [Configuration](#config)
 - [How to get latest version](#getit)
-- API Docs [Core](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-core_2.12/1.3.0/dtrace-core_2.12-1.3.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/index.html) [Logging](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-logging_2.12/1.3.0/dtrace-logging_2.12-1.3.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/logging/index.html)
+- API Docs [Core](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-core_2.12/1.5.0/dtrace-core_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/index.html) [Logging](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-logging_2.12/1.5.0/dtrace-logging_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/logging/index.html)
 
 
 ### <a id="about"></a>About the library
@@ -40,7 +40,7 @@ import org.http4s._
 import org.http4s.dsl.io._
 
 import com.ccadllc.cedi.dtrace._
-import com.ccadllc.cedi.dtrace.interop.htt4s._
+import com.ccadllc.cedi.dtrace.interop.http4s._
 import com.ccadllc.cedi.dtrace.logging.LogEmitter
 
 import TraceSystem._
@@ -196,7 +196,7 @@ Cedi Distributed Trace supports Scala 2.11 and 2.12. This distribution is publis
 This is the core functionality, recording trace and span information over effectful programs, passing these recorded events to registred emitters for disposition.
 
 ```scala
-libraryDependencies += "com.ccadllc.cedi" %% "dtrace-core" % "1.3.0-SNAPSHOT"
+libraryDependencies += "com.ccadllc.cedi" %% "dtrace-core" % "1.5.0"
 ```
 
 #### dtrace-logging
@@ -204,7 +204,7 @@ libraryDependencies += "com.ccadllc.cedi" %% "dtrace-core" % "1.3.0-SNAPSHOT"
 This component provides emitters for logging the trace spans in text and/or JSON format using the `sf4j` logging framework.  It uses the `circe` library for formatting the trace span information as JSON.
 
 ```scala
-libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logging" % "1.3.0-SNAPSHOT"
+libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logging" % "1.5.0"
 ```
 
 #### dtrace-logstash
@@ -212,7 +212,7 @@ libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logging" % "1.3.0-SNAPSHOT
 This component provides emitters for logging in logstash-compliant format.
 
 ```scala
-libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logstash" % "1.3.0-SNAPSHOT"
+libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logstash" % "1.5.0"
 ```
 
 #### dtrace-money interoperability
@@ -220,7 +220,7 @@ libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logstash" % "1.3.0-SNAPSHO
 This component provides an instance of the core HeaderCodec in order to encode and decode Money-compliant HTTP headers.
 
 ```scala
-libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-money" % "1.3.0-SNAPSHOT"
+libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-money" % "1.5.0"
 ```
 
 #### dtrace-xb3 interoperability
@@ -228,7 +228,7 @@ libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-money" % "1.3.0-SNAPSHOT"
 This component provides an insance of the core HeaderCodec in order to encode and decode X-B3/Zipkin-compliant HTTP headers.
 
 ```scala
-libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-xb3" % "1.3.0-SNAPSHOT"
+libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-xb3" % "1.5.0"
 ```
 
 #### dtrace-http4s interoperability
@@ -236,7 +236,7 @@ libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-xb3" % "1.3.0-SNAPSHOT"
 This component provides convenience functions to ingest trace-related HTTP headers (such as Money or X-B3) in an http4s server-side service and to propagate trace-related HTTP headers within an http4s client-side request to a remote entity.  This module is used in combination with either or both the dtrace-xb3 and dtrace-money modules.  If you have another protocol you wish to use instead, it will likewise interoperate with any implementation of the core HeaderCodec trait in implicit scope.
 
 ```scala
-libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-http4s" % "1.3.0-SNAPSHOT"
+libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-http4s" % "1.5.0"
 ```
 
 ## Copyright and License

--- a/readme/src/main/tut/README.md
+++ b/readme/src/main/tut/README.md
@@ -6,7 +6,7 @@ Quick links:
 - [Examples of use](#usage)
 - [Configuration](#config)
 - [How to get latest version](#getit)
-- API Docs [Core](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-core_2.12/1.4.0/dtrace-core_2.12-1.4.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/index.html) [Logging](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-logging_2.12/1.4.0/dtrace-logging_2.12-1.4.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/logging/index.html) [Logstash](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-logstash_2.12/1.4.0/dtrace-logstash_2.12-1.4.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/logstash/index.html)
+- API Docs [Core](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-core_2.12/1.3.0/dtrace-core_2.12-1.3.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/index.html) [Logging](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-logging_2.12/1.3.0/dtrace-logging_2.12-1.3.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/logging/index.html)
 
 
 ### <a id="about"></a>About the library
@@ -30,7 +30,7 @@ A *Distributed Trace* is a directed graph of *Span*s. A *Span* identifies a bran
 
 ### <a id="usage"></a> Examples of Use
 
-```tut:silent
+```scala
 import cats.effect.IO
 
 import java.time.Instant
@@ -40,7 +40,7 @@ import org.http4s._
 import org.http4s.dsl.io._
 
 import com.ccadllc.cedi.dtrace._
-import com.ccadllc.cedi.dtrace.interop.http4s._
+import com.ccadllc.cedi.dtrace.interop.htt4s._
 import com.ccadllc.cedi.dtrace.logging.LogEmitter
 
 import TraceSystem._
@@ -57,7 +57,7 @@ case class SalesFigure(region: String, product: String, units: Int, total: Doubl
  * hold the top-level information about the program (application and node name,
  * deployment and environment names, etc.)
  */
-implicit val traceSystem: TraceSystem[IO] = TraceSystem(
+val traceSystem = TraceSystem(
   metadata = Map(
     "application name" -> "sales-management-system",
     "application ID" -> UUID.randomUUID.toString,
@@ -74,7 +74,22 @@ implicit val traceSystem: TraceSystem[IO] = TraceSystem(
   *   `def emit(tc: TraceContext[F]): F[Unit]` to actually do the work of
   * emitting the current Span to the destination and in the format of your choosing.
   */
-  emitter = LogEmitter[IO]
+  emitter = LogEmitter[IO],
+
+ /*
+  * This time will generate points in time using the `cats.effect.Clock#realTime` function,
+  * which is by default the `System.currentTimeMillis`.  It will convert it to MICROSECONDS
+  * precision in order to calculate the duration of a `Span` execution.  This is just a
+  * convenience function.  There is also a convenience function
+  * - `TraceSystem.monotonicTimer[IO]` - for calculating using the `cats.effect.Clock#monotonic`
+  *  which by default uses `System.nanoTime` and will use its NANOSECOND precision to calculate
+  * the duration of a `Span` execution.  If you'd prefer to use different levels of precision,
+  * you can create a timer using `TraceSystem.Timer.realTime[IO](TimeUnit.MILLISECONDS)`, for
+  * example.  Note that these levels of precision may be rounded up or down if using
+  * `cats.effect.Clock#monotonic`, as it will likely be using `System.currentTimeMillis`
+  * which will only provide millisecond level precision (roughly).
+  *
+  timer = TraceSystem.realTimeTimer[IO]
 )
 
 /* Compose the Money and X-B3 HTTP Trace Header encoder/decoder into an aggregate (generating both on encoded and preferring X-B3 on decode) */
@@ -105,6 +120,7 @@ def generateSalesReport(region: Region): TraceT[IO, SalesReport] = for {
   )
 } yield report
 
+
 /*
  * We add a Span to the overall `generateSalesReport` action,
  * showing the ability to create Span notes from the traced action result
@@ -119,7 +135,7 @@ val tracedIO: TraceT[IO, SalesReport] = generateSalesReport(region).newAnnotated
  */
 val io: IO[SalesReport] = for {
   /* We create a local root Span (we could also extract it from an HTTP header using the `money`, `xb3` and `http4s` modules - see alternate example below) */
-  rootSpan <- Span.root[IO](Span.Name("locally-initiated-report"))
+  rootSpan <- Span.root(traceSystem.timer, Span.Name("locally-initiated-report"))
   /*
    * The tracedIO we've derived earlier around `generateSalesReport` (which includes
    * the retrieval and calculate sales figures nested actions, each with their own Spans) is an instance of `TraceT[IO, A]`,
@@ -136,22 +152,16 @@ val io: IO[SalesReport] = for {
 /*
  * Alternate flow: We convert our traced io to an IO for a htt4s app, possibly continuing an existing trace, if we found
  * either X-B3 or Money HTTP headers in the request; otherwise, a new root trace is generated.
- * We could compose this server action or pass it directly to an http4s blaze server for execution.
  */
-import com.ccadllc.cedi.dtrace.interop.http4s.server._
-import _root_.io.circe.syntax._
-import _root_.io.circe.generic.auto._
-import org.http4s.circe._
-
 val http4sServerAction = HttpService[IO] {
   case request @ GET -> Root / "salesreport" / accountRep =>
     tracedAction(request, Span.Name("sales-report"), Note.string("account-rep", accountRep))(tracedIO).flatMap {
-      salesReport => Ok(salesReport.asJson)
+      salesReport => Response[IO](status = Status.Ok).withBody(salesReport.asJson)
     }
 }
 
 /*
- * Main flow: Now, at the end of the universe, we run the io program.  This will result, in this example using the supplied logging
+ * Now, at the end of the universe, we run the io program.  This will result, in this example using the supplied logging
  * framework Emitter, in the following items logged via the `distributed-trace.txt` logger:
  *   Span: [ span-id=-4268861818882462019 ] [ trace-id=2a71fb7b-f38d-4f6a-a4d1-229c6c5bc963 ] [ parent-id=-6262761813211462065 ]
  *     [ span-name=retrieve-sales-figures] [ app-name=sales-management-system ] [ start-time=2016-09-26T00:29:14.802Z ]
@@ -186,7 +196,7 @@ Cedi Distributed Trace supports Scala 2.11 and 2.12. This distribution is publis
 This is the core functionality, recording trace and span information over effectful programs, passing these recorded events to registred emitters for disposition.
 
 ```scala
-libraryDependencies += "com.ccadllc.cedi" %% "dtrace-core" % "1.4.0"
+libraryDependencies += "com.ccadllc.cedi" %% "dtrace-core" % "1.3.0-SNAPSHOT"
 ```
 
 #### dtrace-logging
@@ -194,7 +204,7 @@ libraryDependencies += "com.ccadllc.cedi" %% "dtrace-core" % "1.4.0"
 This component provides emitters for logging the trace spans in text and/or JSON format using the `sf4j` logging framework.  It uses the `circe` library for formatting the trace span information as JSON.
 
 ```scala
-libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logging" % "1.4.0"
+libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logging" % "1.3.0-SNAPSHOT"
 ```
 
 #### dtrace-logstash
@@ -202,7 +212,7 @@ libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logging" % "1.4.0"
 This component provides emitters for logging in logstash-compliant format.
 
 ```scala
-libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logstash" % "1.4.0"
+libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logstash" % "1.3.0-SNAPSHOT"
 ```
 
 #### dtrace-money interoperability
@@ -210,7 +220,7 @@ libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-logstash" % "1.4.0"
 This component provides an instance of the core HeaderCodec in order to encode and decode Money-compliant HTTP headers.
 
 ```scala
-libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-money" % "1.4.0"
+libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-money" % "1.3.0-SNAPSHOT"
 ```
 
 #### dtrace-xb3 interoperability
@@ -218,7 +228,7 @@ libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-money" % "1.4.0"
 This component provides an insance of the core HeaderCodec in order to encode and decode X-B3/Zipkin-compliant HTTP headers.
 
 ```scala
-libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-xb3" % "1.4.0"
+libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-xb3" % "1.3.0-SNAPSHOT"
 ```
 
 #### dtrace-http4s interoperability
@@ -226,7 +236,7 @@ libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-xb3" % "1.4.0"
 This component provides convenience functions to ingest trace-related HTTP headers (such as Money or X-B3) in an http4s server-side service and to propagate trace-related HTTP headers within an http4s client-side request to a remote entity.  This module is used in combination with either or both the dtrace-xb3 and dtrace-money modules.  If you have another protocol you wish to use instead, it will likewise interoperate with any implementation of the core HeaderCodec trait in implicit scope.
 
 ```scala
-libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-http4s" % "1.4.0"
+libraryDependencies ++= "com.ccadllc.cedi" %% "dtrace-http4s" % "1.3.0-SNAPSHOT"
 ```
 
 ## Copyright and License

--- a/readme/src/main/tut/README.md
+++ b/readme/src/main/tut/README.md
@@ -6,7 +6,7 @@ Quick links:
 - [Examples of use](#usage)
 - [Configuration](#config)
 - [How to get latest version](#getit)
-- API Docs [Core](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-core_2.12/1.5.0/dtrace-core_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/index.html) [Logging](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-logging_2.12/1.5.0/dtrace-logging_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/logging/index.html)
+- API Docs [Core](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-core_2.12/1.5.0/dtrace-core_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/index.html) [Logging](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-logging_2.12/1.5.0/dtrace-logging_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/logging/index.html) [Logstash](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-logstash_2.12/1.5.0/dtrace-logstash_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/logstash/index.html) [Money](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-money_2.12/1.5.0/dtrace-money_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/money/index.html) [Http4s](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-http4s_2.12/1.5.0/dtrace-http4s_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/http4s/index.html) [XB3](https://oss.sonatype.org/service/local/repositories/releases/archive/com/ccadllc/cedi/dtrace-xb3_2.12/1.5.0/dtrace-xb3_2.12-1.5.0-javadoc.jar/!/com/ccadllc/cedi/dtrace/xb3/index.html)
 
 
 ### <a id="about"></a>About the library

--- a/xb3/src/main/scala/com/ccadllc/cedi/dtrace/interop/xb3/XB3HeaderCodec.scala
+++ b/xb3/src/main/scala/com/ccadllc/cedi/dtrace/interop/xb3/XB3HeaderCodec.scala
@@ -27,8 +27,8 @@ import scodec.bits.ByteVector
 import XB3HeaderCodec._
 
 /**
- * Implements the [[HeaderCodec]] trait, providing for the encoding and decoding of
- * `X-B3`-style tracing HTTP headers into and from a [[SpanId]] respectively.
+ * Implements the `HeaderCodec` trait, providing for the encoding and decoding of
+ * `X-B3`-style tracing HTTP headers into and from a `SpanId` respectively.
  */
 class XB3HeaderCodec extends HeaderCodec {
 
@@ -41,15 +41,14 @@ class XB3HeaderCodec extends HeaderCodec {
 
   override def decode(headers: List[Header]): Either[Header.DecodeFailure, Option[SpanId]] = (for {
     traceId <- OptionT(headers.collectFirst { case Header(TraceIdHeaderName, value) => value }.traverse { decodeTraceId })
-    parentIdMaybe <- OptionT.liftF(headers.collectFirst { case Header(ParentIdHeaderName, value) => value }.traverse { decodeSpanId(ParentIdHeaderName, _) })
-    spanId <- OptionT(headers.collectFirst { case Header(SpanIdHeaderName, value) => value }.traverse { decodeSpanId(SpanIdHeaderName, _) })
+    parentIdMaybe <- OptionT.liftF(headers.collectFirst { case Header(ParentIdHeaderName, value) => value }.traverse { decodeSpanId })
+    spanId <- OptionT(headers.collectFirst { case Header(SpanIdHeaderName, value) => value }.traverse { decodeSpanId })
   } yield SpanId(traceId, parentIdMaybe getOrElse spanId, spanId)).value
 
   private def encodeSpanId(spanId: Long): Header.Value = Header.Value(ByteVector.fromLong(spanId).toHex)
   private def encodeTraceId(traceId: UUID): Header.Value = Header.Value(ByteVector.fromUUID(traceId).toHex)
-  private def decodeSpanId(name: Header.CaseInsensitiveName, encoded: Header.Value): Either[Header.DecodeFailure, Long] = if (encoded.value.size === SpanIdMaxCharSize) {
+  private def decodeSpanId(encoded: Header.Value): Either[Header.DecodeFailure, Long] =
     ByteVector.fromHexDescriptive(encoded.value).map { _.toLong() }.leftMap { Header.DecodeFailure(_, None) }
-  } else Either.left(Header.DecodeFailure(s"The $name must be a hexidecimal value $SpanIdMaxCharSize characters in length but was ${encoded.value}", None))
 
   private def decodeTraceId(encoded: Header.Value): Either[Header.DecodeFailure, UUID] = for {
     bv <- ByteVector.fromHexDescriptive(encoded.value).leftMap { Header.DecodeFailure(_, None) }
@@ -62,7 +61,7 @@ class XB3HeaderCodec extends HeaderCodec {
     case TraceIdShortFormByteSize =>
       Either.right(new UUID(bv.toLong(), 0L))
     case other =>
-      Either.left(Header.DecodeFailure(s"The $TraceIdHeaderName must be a hexidecimal value either $TraceIdShortFormByteSize bytes ($TraceIdShortFormCharSize chars) or $TraceIdLongFormByteSize bytes ($TraceIdLongFormCharSize) in length but was ${bv.toHex}", None))
+      Either.left(Header.DecodeFailure(s"The $TraceIdHeaderName must be either $TraceIdShortFormByteSize or $TraceIdLongFormByteSize but was ${bv.toHex}", None))
   }
 }
 
@@ -76,15 +75,10 @@ object XB3HeaderCodec {
   /** The `X-B3` compliant Span ID HTTP header name. */
   final val SpanIdHeaderName: Header.CaseInsensitiveName = Header.CaseInsensitiveName("X-B3-SpanId")
 
-  /** The Span ID / Parent Span ID max char length */
-  final val SpanIdMaxCharSize: Int = 16
-
   /** The number of bytes (long form) of the Trace ID */
   final val TraceIdLongFormByteSize: Long = 16L
-  final val TraceIdLongFormCharSize: Long = TraceIdLongFormByteSize * 2L
 
   /** The number of bytes (short form) of the Trace ID.  Note that the short form is not optimal if you want to ensure unique trace IDs */
   final val TraceIdShortFormByteSize: Long = 8L
-  final val TraceIdShortFormCharSize: Long = TraceIdShortFormByteSize * 2L
 }
 

--- a/xb3/src/test/scala/com/ccadllc/cedi/dtrace/interop/xb3/XB3HeaderCodecTest.scala
+++ b/xb3/src/test/scala/com/ccadllc/cedi/dtrace/interop/xb3/XB3HeaderCodecTest.scala
@@ -57,12 +57,10 @@ class XB3HeaderCodecTest extends WordSpec with Matchers with GeneratorDrivenProp
         val expectedNonRootHeaders = List(
           Header(TraceIdHeaderName, Header.Value(ByteVector.fromUUID(traceIdValue).toHex)),
           Header(ParentIdHeaderName, Header.Value(ByteVector.fromLong(parentSpanIdValue).toHex)),
-          Header(SpanIdHeaderName, Header.Value(ByteVector.fromLong(spanIdValue).toHex))
-        )
+          Header(SpanIdHeaderName, Header.Value(ByteVector.fromLong(spanIdValue).toHex)))
         val expectedRootHeaders = List(
           Header(TraceIdHeaderName, Header.Value(ByteVector.fromUUID(traceIdValue).toHex)),
-          Header(SpanIdHeaderName, Header.Value(ByteVector.fromLong(spanIdValue).toHex))
-        )
+          Header(SpanIdHeaderName, Header.Value(ByteVector.fromLong(spanIdValue).toHex)))
         val spanId = SpanId(traceIdValue, parentSpanIdValue, spanIdValue)
         val headers = headerCodec.encode(spanId)
         val expectedHeaders = if (spanId.root) expectedRootHeaders else expectedNonRootHeaders


### PR DESCRIPTION
…9.  Make TraceT stack safe (or at least stacksafe when the underlying effect is a Monad), added typeclass tests, added ability to use either monotonic or real time time in order to measure span duration.