### PR TITLE
Added ability to encode/decode (from xb3) sampled indicator and propa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 2.0.0
 =====
+ - Added the ability to set a `sampled` indicator in the `TraceContext[F]` and
+   to encode/decode the sampled indicator to/from XB3 headers.  If `sampled`
+   is set to `false` in the `TraceContext`, the actual emission of `Span`s
+   for that trace are skipped.
  - Added an Elastic Common Search (ECS) compliant emitter within the logstash
    module which encodes the spans in a manner consistent with the ECS
    specification (1.0.0-beta2 revision).  The top-level `metadata` map in the

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val catsCoreVersion = "1.6.0"
 
 lazy val circeVersion = "0.11.1"
 
-lazy val http4sVersion = "0.20.0-RC1"
+lazy val http4sVersion = "0.20.0"
 
 lazy val kindProjectorVersion = "0.9.9"
 

--- a/core/jvm/src/test/scala/com/ccadllc/cedi/dtrace/TraceGenerators.scala
+++ b/core/jvm/src/test/scala/com/ccadllc/cedi/dtrace/TraceGenerators.scala
@@ -113,6 +113,7 @@ trait TraceGenerators {
 
   def genTraceContext[F[_]: Effect]: Gen[TraceContext[F]] = for {
     span <- genSpan
+    sampled <- arbitrary[Boolean]
     system <- genTraceSystem[F]
-  } yield TraceContext(span, system)
+  } yield TraceContext(span, sampled, system)
 }

--- a/core/jvm/src/test/scala/com/ccadllc/cedi/dtrace/TypeclassLawTests.scala
+++ b/core/jvm/src/test/scala/com/ccadllc/cedi/dtrace/TypeclassLawTests.scala
@@ -73,6 +73,7 @@ class TypeclassLawTests extends FunSuite with Matchers with Checkers with Discip
     val timer = TraceSystem.realTimeTimer[IO]
     TraceContext(
       Span.root(timer, quarterlySalesCalculateSpanName, quarterlySalesCalculationSpanNotes: _*).unsafeRunSync,
+      true,
       TraceSystem(testSystemData, new TestEmitter[IO], timer))
   }
 

--- a/core/shared/src/main/scala/com/ccadllc/cedi/dtrace/dtrace.scala
+++ b/core/shared/src/main/scala/com/ccadllc/cedi/dtrace/dtrace.scala
@@ -250,9 +250,10 @@ package object dtrace {
 
   private[dtrace] def translate[F[_], G[_]](tc: TraceContext[F], trans: F ~> G): TraceContext[G] = {
     val emitter: TraceSystem.Emitter[G] = new TraceSystem.Emitter[G] {
-      def emit(tcg: TraceContext[G]): G[Unit] = trans(tc.system.emitter.emit(tc.copy(currentSpan = tcg.currentSpan)))
+      def emit(tcg: TraceContext[G]): G[Unit] = trans(
+        tc.system.emitter.emit(tc.copy(currentSpan = tcg.currentSpan, sampled = tcg.sampled)))
       def description: String = tc.system.emitter.description
     }
-    TraceContext(tc.currentSpan, TraceSystem(tc.system.data, emitter, tc.system.timer.translate(trans)))
+    TraceContext(tc.currentSpan, tc.sampled, TraceSystem(tc.system.data, emitter, tc.system.timer.translate(trans)))
   }
 }

--- a/http4s/src/main/scala/com/ccadllc/cedi/dtrace/interop/http4s/server/server.scala
+++ b/http4s/src/main/scala/com/ccadllc/cedi/dtrace/interop/http4s/server/server.scala
@@ -79,9 +79,9 @@ package object server {
     spanName: Span.Name,
     evaluator: Evaluator[A],
     notes: Note*)(action: TraceT[F, A])(implicit codec: HeaderCodec, F: Sync[F], ts: TraceSystem[F]): F[A] = codec.decode(fromHttp4s(req.headers.toList)) match {
-    case Right(spanIdMaybe) =>
-      spanIdMaybe.fold(Span.root[F](ts.timer, spanName, notes: _*)) { Span.newChild[F](ts.timer, _, spanName, notes: _*) }.flatMap { span =>
-        action.trace(TraceContext(span, ts), evaluator, notes: _*)
+    case Right(decoded) =>
+      decoded.spanId.fold(Span.root[F](ts.timer, spanName, notes: _*)) { Span.newChild[F](ts.timer, _, spanName, notes: _*) }.flatMap { span =>
+        action.trace(TraceContext(span, decoded.sampled, ts), evaluator, notes: _*)
       }
     case Left(errDetail) => F.raiseError[A](errDetail)
   }

--- a/logging/jvm/src/test/scala/com/ccadllc/cedi/dtrace/logging/RecordingTestSupport.scala
+++ b/logging/jvm/src/test/scala/com/ccadllc/cedi/dtrace/logging/RecordingTestSupport.scala
@@ -48,7 +48,7 @@ trait RecordingTestSupport extends TestSupport with BeforeAndAfterEach {
 
   protected def assertRootSpanRecorded(): Unit = {
     val spanRoot = Span.root[IO](quarterlySalesCalculationTimer, Span.Name("calculate-quarterly-sales")).unsafeRunSync
-    IO(Thread.sleep(5L)).toTraceT.trace(TraceContext(spanRoot, salesManagementSystem)).unsafeRunSync
+    IO(Thread.sleep(5L)).toTraceT.trace(TraceContext(spanRoot, true, salesManagementSystem)).unsafeRunSync
     LogEmitterTestCache.containingAll(spanId(spanRoot.spanId.spanId), parentSpanId(spanRoot.spanId.spanId), spanName(spanRoot.spanName)) should have size (1)
     ()
   }
@@ -56,7 +56,7 @@ trait RecordingTestSupport extends TestSupport with BeforeAndAfterEach {
   protected def assertChildSpanRecorded(): Unit = {
     val spanRoot = Span.root[IO](quarterlySalesCalculationTimer, Span.Name("calculate-quarterly-sales")).unsafeRunSync
     val retrieveExistingSalesSpanName = Span.Name("retrieve-existing-sales")
-    IO(Thread.sleep(5L)).newSpan(retrieveExistingSalesSpanName).trace(TraceContext(spanRoot, salesManagementSystem)).unsafeRunSync
+    IO(Thread.sleep(5L)).newSpan(retrieveExistingSalesSpanName).trace(TraceContext(spanRoot, true, salesManagementSystem)).unsafeRunSync
     LogEmitterTestCache.containingAll(parentSpanId(spanRoot.spanId.spanId), spanName(retrieveExistingSalesSpanName)) should have size (1)
     LogEmitterTestCache.containingAll(spanId(spanRoot.spanId.spanId)) should have size (1)
     ()
@@ -65,7 +65,7 @@ trait RecordingTestSupport extends TestSupport with BeforeAndAfterEach {
   protected def assertChildSpanRecordedWithNote(note: Note): Unit = {
     val spanRoot = Span.root[IO](quarterlySalesCalculationTimer, Span.Name("calculate-quarterly-sales")).unsafeRunSync
     val retrieveExistingSalesSpanName = Span.Name("retrieve-existing-sales")
-    IO(Thread.sleep(5L)).newSpan(retrieveExistingSalesSpanName, note).trace(TraceContext(spanRoot, salesManagementSystem)).unsafeRunSync
+    IO(Thread.sleep(5L)).newSpan(retrieveExistingSalesSpanName, note).trace(TraceContext(spanRoot, true, salesManagementSystem)).unsafeRunSync
     val entriesWithNote = LogEmitterTestCache.containingAll(parentSpanId(spanRoot.spanId.spanId), spanName(retrieveExistingSalesSpanName), spanNote(note))
     val entriesWithSpanId = LogEmitterTestCache.containingAll(spanId(spanRoot.spanId.spanId))
     entriesWithNote should have size (1)
@@ -84,7 +84,7 @@ trait RecordingTestSupport extends TestSupport with BeforeAndAfterEach {
     } yield ()
     def requestExistingSalesFigures: TraceIO[Boolean] = IO(false).newSpan(requestExistingSalesFiguresSpanName)
     def generateNewSalesFigures: TraceIO[Unit] = IO(Thread.sleep(5L)).newSpan(generateNewSalesFiguresSpanName)
-    calculateSales.trace(TraceContext(spanRoot, salesManagementSystem)).unsafeRunSync
+    calculateSales.trace(TraceContext(spanRoot, true, salesManagementSystem)).unsafeRunSync
     val entries = LogEmitterTestCache.containingAll(logEmitterId)
     entries should have size (3)
     entries(0).msg should include(spanName(requestExistingSalesFiguresSpanName))

--- a/logging/jvm/src/test/scala/com/ccadllc/cedi/dtrace/logging/TestSupport.scala
+++ b/logging/jvm/src/test/scala/com/ccadllc/cedi/dtrace/logging/TestSupport.scala
@@ -37,7 +37,7 @@ trait TestSupport extends WordSpecLike with Matchers with GeneratorDrivenPropert
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 100)
   val salesManagementSystem = TraceSystem(testSystemData, testEmitter[IO].unsafeRunSync, TraceSystem.realTimeTimer[IO])
-  val calculateQuarterlySalesTraceContext = TraceContext(quarterlySalesCalculationSpan, salesManagementSystem)
+  val calculateQuarterlySalesTraceContext = TraceContext(quarterlySalesCalculationSpan, true, salesManagementSystem)
 
   def encodeArbitraryJson[A: Arbitrary](implicit encoder: Lazy[Encoder[A]]): Unit = {
     implicit val e = encoder.value

--- a/logstash/src/test/scala/com/ccadllc/cedi/dtrace/logstash/EcsLogstashLogbackEmitterTest.scala
+++ b/logstash/src/test/scala/com/ccadllc/cedi/dtrace/logstash/EcsLogstashLogbackEmitterTest.scala
@@ -24,7 +24,7 @@ class EcsLogstashLogbackEmitterTest extends WordSpec with TestData {
     "work" in {
       val system = TraceSystem(testSystemData, new EcsLogstashLogbackEmitter[IO], quarterlySalesCalculationTimer)
       val spanRoot = Span.root[IO](quarterlySalesCalculationTimer, Span.Name("calculate-quarterly-sales")).unsafeRunSync
-      IO.unit.toTraceT.trace(TraceContext(spanRoot, system)).unsafeRunSync
+      IO.unit.toTraceT.trace(TraceContext(spanRoot, true, system)).unsafeRunSync
     }
   }
 }

--- a/logstash/src/test/scala/com/ccadllc/cedi/dtrace/logstash/LogstashLogbackEmitterTest.scala
+++ b/logstash/src/test/scala/com/ccadllc/cedi/dtrace/logstash/LogstashLogbackEmitterTest.scala
@@ -24,7 +24,7 @@ class LogstashLogbackEmitterTest extends WordSpec with TestData {
     "work" in {
       val system = TraceSystem(testSystemData, new LogstashLogbackEmitter[IO], quarterlySalesCalculationTimer)
       val spanRoot = Span.root[IO](quarterlySalesCalculationTimer, Span.Name("calculate-quarterly-sales")).unsafeRunSync
-      IO.unit.toTraceT.trace(TraceContext(spanRoot, system)).unsafeRunSync
+      IO.unit.toTraceT.trace(TraceContext(spanRoot, true, system)).unsafeRunSync
     }
   }
 }

--- a/money/jvm/src/test/scala/com/ccadllc/cedi/dtrace/interop/money/MoneyHeaderCodecTest.scala
+++ b/money/jvm/src/test/scala/com/ccadllc/cedi/dtrace/interop/money/MoneyHeaderCodecTest.scala
@@ -37,7 +37,7 @@ class MoneyHeaderCodecTest extends WordSpec with Matchers with GeneratorDrivenPr
           HeaderName,
           Header.Value(s"$TraceIdHeader=$traceIdValue;$ParentIdHeader=$parentSpanIdValue;$SpanIdHeader=$spanIdValue"))
         val errorOrSpanId = headerCodec.decode(List(header))
-        errorOrSpanId shouldBe Right(Some(expectedSpanId))
+        errorOrSpanId shouldBe Right(Header.Decoded(Some(expectedSpanId), true))
       }
     }
     "encode correctly for any valid UUID for trace-Id and any valid long integers for parent and span ID" in {
@@ -55,7 +55,7 @@ class MoneyHeaderCodecTest extends WordSpec with Matchers with GeneratorDrivenPr
         val expectedSpanId = SpanId(traceIdValue, parentSpanIdValue, spanIdValue)
         val headers = headerCodec.encode(expectedSpanId)
         val errorOrSpanId = headerCodec.decode(headers)
-        errorOrSpanId shouldBe Right(Some(expectedSpanId))
+        errorOrSpanId shouldBe Right(Header.Decoded(Some(expectedSpanId), true))
       }
     }
   }

--- a/money/shared/src/main/scala/com/ccadllc/cedi/dtrace/interop/money/MoneyHeaderCodec.scala
+++ b/money/shared/src/main/scala/com/ccadllc/cedi/dtrace/interop/money/MoneyHeaderCodec.scala
@@ -45,14 +45,14 @@ class MoneyHeaderCodec extends HeaderCodec {
    * Decodes a `SpanId` from a [[https://github.com/Comcast/money Comcast Money]]-compliant header.
    * The `properties` argument is currently unused for the `Money` protocol.
    */
-  override def decode(headers: List[Header], properties: Map[String, String]): Either[Header.DecodeFailure, Option[SpanId]] = {
+  override def decode(headers: List[Header], properties: Map[String, String]): Either[Header.DecodeFailure, Header.Decoded] = {
     headers.collectFirst { case Header(HeaderName, Header.Value(value)) => value }.traverse {
       case value @ HeaderRegex(traceId, _, parentId, spanId) =>
         Either.catchNonFatal { SpanId(UUID.fromString(traceId), parentId.toLong, spanId.toLong) }.leftMap { t =>
           Header.DecodeFailure(s"Could not parse $value into a SpanId", Some(t))
         }
       case value => Left(Header.DecodeFailure(s"Could not parse $value into a SpanId", None))
-    }
+    }.map(Header.Decoded(_, true))
   }
 }
 

--- a/xb3/jvm/src/test/scala/com/ccadllc/cedi/dtrace/interop/xb3/XB3HeaderCodecTest.scala
+++ b/xb3/jvm/src/test/scala/com/ccadllc/cedi/dtrace/interop/xb3/XB3HeaderCodecTest.scala
@@ -32,118 +32,131 @@ class XB3HeaderCodecTest extends WordSpec with Matchers with GeneratorDrivenProp
   implicit val arbitraryUUID: Arbitrary[UUID] = Arbitrary(genUUID)
 
   "the X-B3 Header Codec" should {
-    "decode correctly given any valid UUID for trace-Id and any valid long integers for parent and span ID" in {
-      forAll { (traceIdValue: UUID, parentSpanIdValue: Long, spanIdValue: Long) =>
+    "decode correctly given any valid UUID for trace-Id and any valid long integers for parent and span ID and sampled boolean" in {
+      forAll { (traceIdValue: UUID, parentSpanIdValue: Long, spanIdValue: Long, sampled: Boolean) =>
         val expectedSpanId = SpanId(traceIdValue, parentSpanIdValue, spanIdValue)
         val traceIdHeader = Header(TraceIdHeaderName, Header.Value(ByteVector.fromUUID(traceIdValue).toHex))
         val parentIdHeader = Header(ParentIdHeaderName, Header.Value(ByteVector.fromLong(parentSpanIdValue).toHex))
         val spanIdHeader = Header(SpanIdHeaderName, Header.Value(ByteVector.fromLong(spanIdValue).toHex))
-        val errorOrSpanId = headerCodec.decode(List(traceIdHeader, parentIdHeader, spanIdHeader))
-        errorOrSpanId shouldBe Right(Some(expectedSpanId))
+        val sampledHeader = Header(SampledHeaderName, Header.Value(encodeSampledValue(sampled)))
+        val errorOrSpanId = headerCodec.decode(List(traceIdHeader, parentIdHeader, spanIdHeader, sampledHeader))
+        errorOrSpanId shouldBe Right(Header.Decoded(Some(expectedSpanId), sampled))
       }
     }
-    "decode correctly for compressed header given any valid UUID for trace-Id and any valid long integers for parent and span ID" in {
-      forAll { (traceIdValue: UUID, parentSpanIdValue: Long, spanIdValue: Long) =>
+    "decode correctly for compressed header given any valid UUID for trace-Id and any valid long integers for parent and span ID and sampled boolean" in {
+      forAll { (traceIdValue: UUID, parentSpanIdValue: Long, spanIdValue: Long, sampled: Boolean) =>
         val expectedSpanId = SpanId(traceIdValue, parentSpanIdValue, spanIdValue)
         val nonRootHeaders = List(
           Header(
             CompressedHeaderName,
-            Header.Value(s"${ByteVector.fromUUID(traceIdValue).toHex}-${ByteVector.fromLong(spanIdValue).toHex}-0-${ByteVector.fromLong(parentSpanIdValue).toHex}")))
+            Header.Value(s"${ByteVector.fromUUID(traceIdValue).toHex}-${ByteVector.fromLong(spanIdValue).toHex}-${encodeSampledValue(sampled)}-${ByteVector.fromLong(parentSpanIdValue).toHex}")))
         val rootHeaders = List(
           Header(
             CompressedHeaderName,
-            Header.Value(s"${ByteVector.fromUUID(traceIdValue).toHex}-${ByteVector.fromLong(spanIdValue).toHex}")))
+            Header.Value(s"${ByteVector.fromUUID(traceIdValue).toHex}-${ByteVector.fromLong(spanIdValue).toHex}-${encodeSampledValue(sampled)}")))
         val errorOrSpanId = headerCodec.decode(if (parentSpanIdValue === spanIdValue) rootHeaders else nonRootHeaders)
-        errorOrSpanId shouldBe Right(Some(expectedSpanId))
+        errorOrSpanId shouldBe Right(Header.Decoded(Some(expectedSpanId), sampled))
       }
     }
-    "decode correctly given any valid long for trace-Id and any valid long integers for parent and span ID" in {
-      forAll { (traceIdValue: Long, parentSpanIdValue: Long, spanIdValue: Long) =>
+    "decode correctly given any valid long for trace-Id and any valid long integers for parent and span ID and sampled boolean" in {
+      forAll { (traceIdValue: Long, parentSpanIdValue: Long, spanIdValue: Long, sampled: Boolean) =>
         val expectedSpanId = SpanId(new UUID(traceIdValue, 0L), parentSpanIdValue, spanIdValue)
         val traceIdHeader = Header(TraceIdHeaderName, Header.Value(ByteVector.fromLong(traceIdValue).toHex))
         val parentIdHeader = Header(ParentIdHeaderName, Header.Value(ByteVector.fromLong(parentSpanIdValue).toHex))
         val spanIdHeader = Header(SpanIdHeaderName, Header.Value(ByteVector.fromLong(spanIdValue).toHex))
-        val errorOrSpanId = headerCodec.decode(List(traceIdHeader, parentIdHeader, spanIdHeader))
-        errorOrSpanId shouldBe Right(Some(expectedSpanId))
+        val sampledHeader = Header(SampledHeaderName, Header.Value(encodeSampledValue(sampled)))
+        val errorOrSpanId = headerCodec.decode(List(traceIdHeader, parentIdHeader, spanIdHeader, sampledHeader))
+        errorOrSpanId shouldBe Right(Header.Decoded(Some(expectedSpanId), sampled))
       }
     }
-    "decode correctly for compressed header given any valid long for trace-Id and any valid long integers for parent and span ID" in {
-      forAll { (traceIdValue: Long, parentSpanIdValue: Long, spanIdValue: Long) =>
+    "decode correctly for compressed header given any valid long for trace-Id and any valid long integers for parent and span ID and sampled boolean" in {
+      forAll { (traceIdValue: Long, parentSpanIdValue: Long, spanIdValue: Long, sampled: Boolean) =>
         val expectedSpanId = SpanId(new UUID(traceIdValue, 0L), parentSpanIdValue, spanIdValue)
         val nonRootHeaders = List(
           Header(
             CompressedHeaderName,
-            Header.Value(s"${ByteVector.fromUUID(expectedSpanId.traceId).toHex}-${ByteVector.fromLong(spanIdValue).toHex}-0-${ByteVector.fromLong(parentSpanIdValue).toHex}")))
+            Header.Value(s"${ByteVector.fromUUID(expectedSpanId.traceId).toHex}-${ByteVector.fromLong(spanIdValue).toHex}-${encodeSampledValue(sampled)}-${ByteVector.fromLong(parentSpanIdValue).toHex}")))
         val rootHeaders = List(
           Header(
             CompressedHeaderName,
-            Header.Value(s"${ByteVector.fromUUID(expectedSpanId.traceId).toHex}-${ByteVector.fromLong(spanIdValue).toHex}")))
+            Header.Value(s"${ByteVector.fromUUID(expectedSpanId.traceId).toHex}-${ByteVector.fromLong(spanIdValue).toHex}-${encodeSampledValue(sampled)}")))
         val errorOrSpanId = headerCodec.decode(if (parentSpanIdValue === spanIdValue) rootHeaders else nonRootHeaders)
-        errorOrSpanId shouldBe Right(Some(expectedSpanId))
+        errorOrSpanId shouldBe Right(Header.Decoded(Some(expectedSpanId), sampled))
       }
     }
-    "encode correctly for any valid UUID for trace-Id and any valid long integers for parent and span ID, where if parent == span id, parent will not be emitted" in {
-      forAll { (traceIdValue: UUID, parentSpanIdValue: Long, spanIdValue: Long) =>
+    "encode correctly for any valid UUID for trace-Id and any valid long integers for parent and span ID and sampled boolean, where if parent == span id, parent will not be emitted" in {
+      forAll { (traceIdValue: UUID, parentSpanIdValue: Long, spanIdValue: Long, sampled: Boolean) =>
         val expectedNonRootHeaders = List(
           Header(TraceIdHeaderName, Header.Value(ByteVector.fromUUID(traceIdValue).toHex)),
           Header(ParentIdHeaderName, Header.Value(ByteVector.fromLong(parentSpanIdValue).toHex)),
-          Header(SpanIdHeaderName, Header.Value(ByteVector.fromLong(spanIdValue).toHex)))
+          Header(SpanIdHeaderName, Header.Value(ByteVector.fromLong(spanIdValue).toHex)),
+          Header(SampledHeaderName, Header.Value(encodeSampledValue(sampled))))
         val expectedRootHeaders = List(
           Header(TraceIdHeaderName, Header.Value(ByteVector.fromUUID(traceIdValue).toHex)),
-          Header(SpanIdHeaderName, Header.Value(ByteVector.fromLong(spanIdValue).toHex)))
+          Header(SpanIdHeaderName, Header.Value(ByteVector.fromLong(spanIdValue).toHex)),
+          Header(SampledHeaderName, Header.Value(encodeSampledValue(sampled))))
         val spanId = SpanId(traceIdValue, parentSpanIdValue, spanIdValue)
-        val headers = headerCodec.encode(spanId)
+        val headers = headerCodec.encode(spanId, Map(XB3HeaderCodec.Sampled -> sampled.toString))
         val expectedHeaders = if (spanId.root) expectedRootHeaders else expectedNonRootHeaders
         headers shouldBe expectedHeaders
       }
     }
-    "encode correctly for compressed header for any valid UUID for trace-Id and any valid long integers for parent and span ID, where if parent == span id, parent will not be emitted" in {
-      forAll { (traceIdValue: UUID, parentSpanIdValue: Long, spanIdValue: Long) =>
+    "encode correctly for compressed header for any valid UUID for trace-Id and any valid long integers for parent and span ID and sampled boolean, where if parent == span id, parent will not be emitted" in {
+      forAll { (traceIdValue: UUID, parentSpanIdValue: Long, spanIdValue: Long, sampled: Boolean) =>
         val expectedNonRootHeaders = List(
           Header(
             CompressedHeaderName,
-            Header.Value(s"${ByteVector.fromUUID(traceIdValue).toHex}-${ByteVector.fromLong(spanIdValue).toHex}-0-${ByteVector.fromLong(parentSpanIdValue).toHex}")))
+            Header.Value(s"${ByteVector.fromUUID(traceIdValue).toHex}-${ByteVector.fromLong(spanIdValue).toHex}-${encodeSampledValue(sampled)}-${ByteVector.fromLong(parentSpanIdValue).toHex}")))
         val expectedRootHeaders = List(
           Header(
             CompressedHeaderName,
-            Header.Value(s"${ByteVector.fromUUID(traceIdValue).toHex}-${ByteVector.fromLong(spanIdValue).toHex}")))
+            Header.Value(s"${ByteVector.fromUUID(traceIdValue).toHex}-${ByteVector.fromLong(spanIdValue).toHex}-${encodeSampledValue(sampled)}")))
         val spanId = SpanId(traceIdValue, parentSpanIdValue, spanIdValue)
-        val headers = headerCodec.encode(spanId, Map(XB3HeaderCodec.Compressed -> "true"))
+        val headers = headerCodec.encode(
+          spanId,
+          Map(XB3HeaderCodec.Compressed -> "true", XB3HeaderCodec.Sampled -> sampled.toString))
         val expectedHeaders = if (spanId.root) expectedRootHeaders else expectedNonRootHeaders
         headers shouldBe expectedHeaders
       }
     }
-    "round-trip correctly given any valid UUID for trace-Id and any valid long integers for parent and span ID" in {
-      forAll { (traceIdValue: UUID, parentSpanIdValue: Long, spanIdValue: Long) =>
+    "round-trip correctly given any valid UUID for trace-Id and any valid long integers for parent and span ID and sampled boolean" in {
+      forAll { (traceIdValue: UUID, parentSpanIdValue: Long, spanIdValue: Long, sampled: Boolean) =>
         val expectedSpanId = SpanId(traceIdValue, parentSpanIdValue, spanIdValue)
-        val headers = headerCodec.encode(expectedSpanId)
+        val headers = headerCodec.encode(
+          expectedSpanId,
+          Map(XB3HeaderCodec.Sampled -> sampled.toString, XB3HeaderCodec.Sampled -> sampled.toString))
         val errorOrSpanId = headerCodec.decode(headers)
-        errorOrSpanId shouldBe Right(Some(expectedSpanId))
+        errorOrSpanId shouldBe Right(Header.Decoded(Some(expectedSpanId), sampled))
       }
     }
-    "round-trip correctly for compressed header given any valid UUID for trace-Id and any valid long integers for parent and span ID" in {
-      forAll { (traceIdValue: UUID, parentSpanIdValue: Long, spanIdValue: Long) =>
+    "round-trip correctly for compressed header given any valid UUID for trace-Id and any valid long integers for parent and span ID and sampled boolean" in {
+      forAll { (traceIdValue: UUID, parentSpanIdValue: Long, spanIdValue: Long, sampled: Boolean) =>
         val expectedSpanId = SpanId(traceIdValue, parentSpanIdValue, spanIdValue)
-        val headers = headerCodec.encode(expectedSpanId, Map(XB3HeaderCodec.Compressed -> "true"))
+        val headers = headerCodec.encode(
+          expectedSpanId,
+          Map(XB3HeaderCodec.Compressed -> "true", XB3HeaderCodec.Sampled -> sampled.toString))
         val errorOrSpanId = headerCodec.decode(headers)
-        errorOrSpanId shouldBe Right(Some(expectedSpanId))
+        errorOrSpanId shouldBe Right(Header.Decoded(Some(expectedSpanId), sampled))
       }
     }
-    "round-trip correctly given any valid long for trace-Id and any valid long integers for parent and span ID" in {
-      forAll { (traceIdValue: Long, parentSpanIdValue: Long, spanIdValue: Long) =>
+    "round-trip correctly given any valid long for trace-Id and any valid long integers for parent and span ID and sampled boolean" in {
+      forAll { (traceIdValue: Long, parentSpanIdValue: Long, spanIdValue: Long, sampled: Boolean) =>
         val expectedSpanId = SpanId(new UUID(traceIdValue, 0L), parentSpanIdValue, spanIdValue)
-        val headers = headerCodec.encode(expectedSpanId)
+        val headers = headerCodec.encode(expectedSpanId, Map(XB3HeaderCodec.Sampled -> sampled.toString))
         val errorOrSpanId = headerCodec.decode(headers)
-        errorOrSpanId shouldBe Right(Some(expectedSpanId))
+        errorOrSpanId shouldBe Right(Header.Decoded(Some(expectedSpanId), sampled))
       }
     }
-    "round-trip correctly for compressed header given any valid long for trace-Id and any valid long integers for parent and span ID" in {
-      forAll { (traceIdValue: Long, parentSpanIdValue: Long, spanIdValue: Long) =>
+    "round-trip correctly for compressed header given any valid long for trace-Id and any valid long integers for parent and span ID and sampled boolean" in {
+      forAll { (traceIdValue: Long, parentSpanIdValue: Long, spanIdValue: Long, sampled: Boolean) =>
         val expectedSpanId = SpanId(new UUID(traceIdValue, 0L), parentSpanIdValue, spanIdValue)
-        val headers = headerCodec.encode(expectedSpanId, Map(XB3HeaderCodec.Compressed -> "true"))
+        val headers = headerCodec.encode(
+          expectedSpanId,
+          Map(XB3HeaderCodec.Compressed -> "true", XB3HeaderCodec.Sampled -> sampled.toString))
         val errorOrSpanId = headerCodec.decode(headers)
-        errorOrSpanId shouldBe Right(Some(expectedSpanId))
+        errorOrSpanId shouldBe Right(Header.Decoded(Some(expectedSpanId), sampled))
       }
     }
   }
+  private def encodeSampledValue(sampled: Boolean): String = if (sampled) "1" else "0"
 }

--- a/xb3/shared/src/main/scala/com/ccadllc/cedi/dtrace/interop/xb3/XB3HeaderCodec.scala
+++ b/xb3/shared/src/main/scala/com/ccadllc/cedi/dtrace/interop/xb3/XB3HeaderCodec.scala
@@ -40,9 +40,16 @@ class XB3HeaderCodec extends HeaderCodec {
    * Note: A single `b3` compressed header will be generated combining the `traceId`, `spanId`
    * and `parentSpanId` when this function is called using the form:
    *  `xb3HeaderCodec.encode(spanId, Map(XB3HeaderCodec.Compressed -> "true"))`
+   * Note: The `X-B3-Sampled` Header will be set to "0" if called with the below form (where it might be combined
+   * with with `Compressed` as shown above, in which case the sampled section of the compressed header will
+   * be set to "0").  Otherwise the `X-B3-Sampled` header (or sampled section of compressed header) will be
+   * set to "1"
+   *  `xb3HeaderCodec.encode(spanId, Map(XB3HeaderCodec.Sampled -> "false"))`
    */
-  override def encode(spanId: SpanId, properties: Map[String, String]): List[Header] =
-    if (compressHeaders(properties)) encodeCompressed(spanId) else encodeUncompressed(spanId)
+  override def encode(spanId: SpanId, properties: Map[String, String]): List[Header] = {
+    val sampled = sampleTrace(properties)
+    if (compressHeaders(properties)) encodeCompressed(spanId, sampled) else encodeUncompressed(spanId, sampled)
+  }
 
   /**
    * Decodes a `SpanId` from
@@ -50,22 +57,24 @@ class XB3HeaderCodec extends HeaderCodec {
    * HTTP headers (or single compressed `b3` header if present).
    * The `properties` argument is not currently used with this function.
    */
-  override def decode(headers: List[Header], properties: Map[String, String]): Either[Header.DecodeFailure, Option[SpanId]] =
-    decodeCompressed(headers).flatMap(_.fold(decodeUncompressed(headers))(h => Right(Some(h))))
+  override def decode(headers: List[Header], properties: Map[String, String]): Either[Header.DecodeFailure, Header.Decoded] =
+    decodeCompressed(headers).flatMap(d => if (d.spanId.isEmpty) decodeUncompressed(headers) else Right(d))
 
   private def compressHeaders(properties: Map[String, String]): Boolean =
-    properties.get(Compressed).flatMap(s => Either.catchNonFatal(s.toBoolean).toOption).exists(identity)
+    properties.get(Compressed).flatMap(s => Either.catchNonFatal(s.toBoolean).toOption).getOrElse(false)
 
-  private def decodeCompressed(headers: List[Header]): Either[Header.DecodeFailure, Option[SpanId]] =
-    headers.collectFirst { case Header(CompressedHeaderName, value) => value }.traverse(decodeCompressedSpanId)
+  private def decodeCompressed(headers: List[Header]): Either[Header.DecodeFailure, Header.Decoded] =
+    headers.collectFirst { case Header(CompressedHeaderName, value) => value }.traverse(decodeCompressedSpanId).map(
+      _.fold(Header.Decoded(None, true)) { case (spanId, sampled) => Header.Decoded(Some(spanId), sampled) })
 
-  private def decodeCompressedSpanId(encoded: Header.Value): Either[Header.DecodeFailure, SpanId] = encoded.value match {
-    case CompressedHeaderRegex(traceId, spanId, parentId) =>
+  private def decodeCompressedSpanId(encoded: Header.Value): Either[Header.DecodeFailure, (SpanId, Boolean)] = encoded.value match {
+    case CompressedHeaderRegex(traceId, spanId, sampled, parentId) =>
       (for {
         traceId <- decodeTraceIdValue(traceId)
         spanId <- decodeSpanIdValue(spanId)
         parentId <- Option(parentId).fold(Either.right[Header.DecodeFailure, Long](spanId))(decodeSpanIdValue)
-      } yield SpanId(traceId, parentId, spanId)).leftMap(e => Header.DecodeFailure(s"${e.message} within ${encoded.value}", e.cause))
+      } yield SpanId(traceId, parentId, spanId) -> Option(sampled).forall(_ =!= "0")).leftMap(
+        e => Header.DecodeFailure(s"${e.message} within ${encoded.value}", e.cause))
     case value => Left(Header.DecodeFailure(s"Could not parse $value into a SpanId", None))
   }
 
@@ -83,11 +92,16 @@ class XB3HeaderCodec extends HeaderCodec {
     uuid <- decodeUuid(bv)
   } yield uuid
 
-  private def decodeUncompressed(headers: List[Header]): Either[Header.DecodeFailure, Option[SpanId]] = (for {
-    traceId <- OptionT(headers.collectFirst { case Header(TraceIdHeaderName, value) => value }.traverse(decodeTraceId))
-    parentIdMaybe <- OptionT.liftF(headers.collectFirst { case Header(ParentIdHeaderName, value) => value }.traverse(decodeSpanId))
-    spanId <- OptionT(headers.collectFirst { case Header(SpanIdHeaderName, value) => value }.traverse(decodeSpanId))
-  } yield SpanId(traceId, parentIdMaybe getOrElse spanId, spanId)).value
+  private def decodeUncompressed(headers: List[Header]): Either[Header.DecodeFailure, Header.Decoded] = {
+    val spanIdAndSampled = for {
+      traceId <- OptionT(headers.collectFirst { case Header(TraceIdHeaderName, value) => value }.traverse(decodeTraceId))
+      parentIdMaybe <- OptionT.liftF(headers.collectFirst { case Header(ParentIdHeaderName, value) => value }.traverse(decodeSpanId))
+      spanId <- OptionT(headers.collectFirst { case Header(SpanIdHeaderName, value) => value }.traverse(decodeSpanId))
+      sampled = headers.collectFirst { case Header(SampledHeaderName, value) => value.value =!= "0" }.getOrElse(true)
+    } yield SpanId(traceId, parentIdMaybe getOrElse spanId, spanId) -> sampled
+    spanIdAndSampled.value.map(
+      _.fold(Header.Decoded(None, true)) { case (spanId, sampled) => Header.Decoded(Some(spanId), sampled) })
+  }
 
   private def decodeUuid(bv: ByteVector): Either[Header.DecodeFailure, UUID] = bv.size match {
     case TraceIdLongFormByteSize =>
@@ -98,23 +112,29 @@ class XB3HeaderCodec extends HeaderCodec {
       Either.left(Header.DecodeFailure(s"The $TraceIdHeaderName must be either $TraceIdShortFormByteSize or $TraceIdLongFormByteSize but was ${bv.toHex}", None))
   }
 
-  private def encodeCompressed(spanId: SpanId): List[Header] = {
-    val hv = if (spanId.root) s"${encodeTraceIdValue(spanId.traceId)}-${encodeSpanIdValue(spanId.spanId)}" else
-      s"${encodeTraceIdValue(spanId.traceId)}-${encodeSpanIdValue(spanId.spanId)}-0-${encodeSpanIdValue(spanId.parentSpanId)}"
+  private def encodeCompressed(spanId: SpanId, sampled: Boolean): List[Header] = {
+    val hv = if (spanId.root) s"${encodeTraceIdValue(spanId.traceId)}-${encodeSpanIdValue(spanId.spanId)}-${encodeSampledValue(sampled)}" else
+      s"${encodeTraceIdValue(spanId.traceId)}-${encodeSpanIdValue(spanId.spanId)}-${encodeSampledValue(sampled)}-${encodeSpanIdValue(spanId.parentSpanId)}"
     List(Header(CompressedHeaderName, Header.Value(hv)))
   }
 
-  private def encodeUncompressed(spanId: SpanId): List[Header] = {
+  private def encodeUncompressed(spanId: SpanId, sampled: Boolean): List[Header] = {
     val traceIdH = List(Header(TraceIdHeaderName, encodeTraceId(spanId.traceId)))
     val parentIdH = if (spanId.root) List.empty[Header] else List(Header(ParentIdHeaderName, encodeSpanId(spanId.parentSpanId)))
     val spanIdH = List(Header(SpanIdHeaderName, encodeSpanId(spanId.spanId)))
-    traceIdH ++ parentIdH ++ spanIdH
+    val sampledH = List(Header(SampledHeaderName, encodeSampled(sampled)))
+    traceIdH ++ parentIdH ++ spanIdH ++ sampledH
   }
 
+  private def encodeSampled(sampled: Boolean): Header.Value = Header.Value(encodeSampledValue(sampled))
+  private def encodeSampledValue(sampled: Boolean): String = if (sampled) "1" else "0"
   private def encodeSpanId(spanId: Long): Header.Value = Header.Value(encodeSpanIdValue(spanId))
   private def encodeSpanIdValue(spanId: Long): String = ByteVector.fromLong(spanId).toHex
   private def encodeTraceId(traceId: UUID): Header.Value = Header.Value(encodeTraceIdValue(traceId))
   private def encodeTraceIdValue(traceId: UUID): String = ByteVector.fromUUID(traceId).toHex
+
+  private def sampleTrace(properties: Map[String, String]): Boolean =
+    properties.get(Sampled).flatMap(s => Either.catchNonFatal(s.toBoolean).toOption).getOrElse(true)
 }
 
 object XB3HeaderCodec {
@@ -125,8 +145,16 @@ object XB3HeaderCodec {
    */
   final val Compressed: String = "compressed-headers"
 
+  /**
+   * Property to pass to the `HeaderCodec.encode` method's `properties` that, when set to "true",
+   * indicates the X-B3-Sampled header (or "sampled" section of compressed header) should be set to "1"
+   * and when false that it should be set to "0".  If not present, the flag will be set to "1" by
+   * default in X-B3-Sampled Header/compressed sampled section as appropriate.
+   */
+  final val Sampled: String = "sampled"
+
   /* Used to validate / parse B3 compressed HTTP header into a `SpanId` instance. */
-  final val CompressedHeaderRegex: Regex = s"([0-9a-fA-F]+)-([0-9a-fA-F]+)(?:-[0-9a-fA-F])?(?:-([0-9a-fA-F]+))?".r
+  final val CompressedHeaderRegex: Regex = s"([0-9a-fA-F]+)-([0-9a-fA-F]+)(?:-([0-1]))?(?:-([0-9a-fA-F]+))?".r
 
   /** The `X-B3` compliant compressed header format where TraceID-SpanId-ParentId are embedded in a single header */
   final val CompressedHeaderName: Header.CaseInsensitiveName = Header.CaseInsensitiveName("b3")
@@ -139,6 +167,9 @@ object XB3HeaderCodec {
 
   /** The `X-B3` compliant Span ID HTTP header name. */
   final val SpanIdHeaderName: Header.CaseInsensitiveName = Header.CaseInsensitiveName("X-B3-SpanId")
+
+  /** The `X-B3` compliant Sampled HTTP header name. */
+  final val SampledHeaderName: Header.CaseInsensitiveName = Header.CaseInsensitiveName("X-B3-Sampled")
 
   /** The number of bytes (long form) of the Trace ID */
   final val TraceIdLongFormByteSize: Long = 16L


### PR DESCRIPTION
…gate that to the TraceContext, respecting that indicator when determining whether or not we wish to emit spans.  Users can also set sampled directly in TraceContext as needed.  See #71 