### PR TITLE
Added further hackery to dtrace's inadequate stack safety mechanism s…

### DIFF
--- a/core/jvm/src/test/scala/com/ccadllc/cedi/dtrace/TypeclassLawTests.scala
+++ b/core/jvm/src/test/scala/com/ccadllc/cedi/dtrace/TypeclassLawTests.scala
@@ -181,7 +181,7 @@ class TypeclassLawTests extends FunSuite with Matchers with Checkers with Discip
 
   testAsync("parMap2 should be stack safe") { testC =>
     implicit val cs = testC.contextShift[IO]
-    val count = 100000
+    val count = 500000
     val tasks = (0 until count).map(_ => TraceIO(1))
     val sum = tasks.foldLeft(TraceIO(0))((acc, t) => (acc, t).parMapN(_ + _))
     val f = sum.trace(tc).unsafeToFuture()
@@ -192,7 +192,7 @@ class TypeclassLawTests extends FunSuite with Matchers with Checkers with Discip
 
   testAsync("parTraverse should be stack safe") { testC =>
     implicit val cs = testC.contextShift[IO]
-    val count = 100000
+    val count = 500000
     val numbers = (0 until count).toVector
     val f = numbers.parTraverse(i => TraceIO.pure(i + 1)).trace(tc).unsafeToFuture()
     testC.tick()

--- a/core/shared/src/main/scala/com/ccadllc/cedi/dtrace/dtrace.scala
+++ b/core/shared/src/main/scala/com/ccadllc/cedi/dtrace/dtrace.scala
@@ -53,6 +53,18 @@ package object dtrace {
         IO.Par.unwrap(tiop.toEffect(translate(tc, P.parallel)))
       }
     }
+    /**
+     * Creates a simple, noncancelable `TraceIO[A]` instance that
+     * executes an asynchronous process on evaluation.
+     *
+     * The given function is being injected with a side-effectful
+     * callback for signaling the final result of an asynchronous
+     * process.
+     *
+     * @param k is a function that should be called with a
+     *       callback for signaling the result once it is ready
+     */
+    def async[A](cb: (Either[Throwable, A] => Unit) => Unit): TraceIO[A] = toTraceIO(IO.async(cb))
 
     /**
      * Ask for the current `TraceContext[IO]` in a `TraceIO`.


### PR DESCRIPTION
…ince manufactored applicative type of parallel isn't a monad and thus can't directly use our original hack.  Fixes immediate stack overflow issue with parTraverse.  Opened an issue to fix properly but that'll take longer/need some more thought.  Fixes issue #77 