### PR TITLE
Updated to support scala 2.13

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,2 @@
+-J-Xms4g
+-J-Xmx4g

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+2.1.0
+=====
+ - Support for scala 2.13 and updated libraries (notably using scalatest for
+   property testing).  Note that we can now move (most) tests into shared
+   and use AsyncFreeSpec, with the exception of that which we inherit from
+   cats-effect, which is still using scalacheck.  This will be done in
+   a subsequent point release as its an implementation detail which does not
+   affect the library API.  This version requires and depends on
+   cedi-build 1.2.0.
 2.0.2
 =====
  - Fix Stack Overflow for parTraverse.  Issue #79.

--- a/build.sbt
+++ b/build.sbt
@@ -1,37 +1,33 @@
 import sbtcrossproject.crossProject
 
-lazy val catsEffectVersion = "1.2.0"
+lazy val catsEffectVersion = "2.0.0-M4"
 
-lazy val catsCoreVersion = "1.6.0"
+lazy val catsCoreVersion = "2.0.0-M4"
 
-lazy val circeVersion = "0.11.1"
+lazy val circeVersion = "0.12.0-M3"
 
-lazy val http4sVersion = "0.20.0"
+lazy val http4sVersion = "0.21.0-M1"
 
-lazy val kindProjectorVersion = "0.9.9"
+lazy val kindProjectorVersion = "0.10.3"
 
 lazy val logbackVersion = "1.2.3"
 
 lazy val logstashVersion = "5.3"
 
-lazy val scalacheckVersion = "1.13.5"
+lazy val scalacheckVersion = "1.14.0"
 
-lazy val scalatestVersion = "3.0.5"
+lazy val scalatestVersion = "3.1.0-SNAP13"
 
-lazy val scalacheckVersion213 = "1.14.0"
-
-lazy val scalatestVersion213 = "3.0.6-SNAP5"
-
-lazy val scodecBitsVersion = "1.1.9"
+lazy val scodecBitsVersion = "1.1.12"
 
 lazy val slf4jVersion = "1.7.26"
 
-lazy val log4catsVersion = "0.3.0"
+lazy val log4catsVersion = "0.4.0-M1"
 
 lazy val commonSettings = Seq(
   githubProject := "cedi-dtrace",
   parallelExecution in Global := !scala.util.Properties.propIsSet("disableParallel"),
-  crossScalaVersions := Seq("2.12.8", "2.11.12"),
+  crossScalaVersions := Seq("2.13.0", "2.12.8", "2.11.12"),
   scalacOptions in (Compile, console) ~= (_ filterNot Set("-Xfatal-warnings", "-Ywarn-unused-import").contains),
   contributors ++= Seq(
     Contributor("sbuzzard", "Steve Buzzard"),
@@ -39,18 +35,11 @@ lazy val commonSettings = Seq(
   ),
   libraryDependencies ++= Seq(
     "org.typelevel" %% "cats-core" % catsCoreVersion,
-    "org.typelevel" %% "cats-effect" % catsEffectVersion
-  ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, v)) if v >= 13 => Seq(
-      "org.scalatest" %% "scalatest" % scalatestVersion213 % "test",
-      "org.scalacheck" %% "scalacheck" % scalacheckVersion213 % "test"
-    )
-    case _ => Seq(
-      "org.scalatest" %% "scalatest" % scalatestVersion % "test",
-      "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test"
-    )
-  }),
-  addCompilerPlugin("org.spire-math" %% "kind-projector" % kindProjectorVersion),
+    "org.typelevel" %% "cats-effect" % catsEffectVersion,
+    "org.scalatest" %% "scalatest" % scalatestVersion % "test",
+    "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test"
+  ),
+  addCompilerPlugin("org.typelevel" % "kind-projector" % kindProjectorVersion cross CrossVersion.binary),
   pomExtra := (
     <url>http://github.com/ccadllc/{githubProject.value}</url>
     <developers>
@@ -126,27 +115,12 @@ lazy val loggingJVM = logging.jvm.enablePlugins(SbtOsgi).
     buildOsgiBundle("com.ccadllc.cedi.dtrace.logging")
   ).dependsOn(coreJVM % "compile->compile;test->test")
 
-lazy val loggingJS = logging.js.
-  settings(
-    // TODO: This is only temporary until log4cats (and log4s) publishes for 2.13
-    // Replace this libDependencies and the two skips with just a
-    // libDeps for the slogging lib
-    libraryDependencies := (CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, v)) if v >= 13 => Seq.empty
-      case _ => libraryDependencies.value ++ Seq(
-        "io.chrisdavenport" %%% "log4cats-core" % log4catsVersion,
-        "io.chrisdavenport" %%% "log4cats-log4s" % log4catsVersion
-      )
-    }),
-    skip in compile := (CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, v)) => v >= 13
-      case _ => false
-    }),
-    skip in publish := (CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, v)) => v >= 13
-      case _ => false
-    })
-  ).dependsOn(coreJS % "compile->compile;test->test")
+lazy val loggingJS = logging.js.settings(
+  libraryDependencies ++= Seq(
+    "io.chrisdavenport" %%% "log4cats-core" % log4catsVersion,
+    "io.chrisdavenport" %%% "log4cats-log4s" % log4catsVersion
+  )
+).dependsOn(coreJS % "compile->compile;test->test")
 
 lazy val logstash = project.in(file("logstash")).enablePlugins(SbtOsgi).
   settings(commonSettings).

--- a/core/jvm/src/test/scala/com/ccadllc/cedi/dtrace/TestEmitterRecordingTest.scala
+++ b/core/jvm/src/test/scala/com/ccadllc/cedi/dtrace/TestEmitterRecordingTest.scala
@@ -21,9 +21,10 @@ import cats.implicits._
 
 import scala.concurrent.ExecutionContext
 
-import org.scalatest.{ BeforeAndAfterEach, Matchers, WordSpec }
+import org.scalatest.{ BeforeAndAfterEach, Matchers }
+import org.scalatest.wordspec.AnyWordSpec
 
-class TestEmitterRecordingTest extends WordSpec with BeforeAndAfterEach with Matchers with TestData {
+class TestEmitterRecordingTest extends AnyWordSpec with BeforeAndAfterEach with Matchers with TestData {
   "the distributed trace recording mechanism for emitting to a test string emitter" should {
     "support recording a successful current tracing span which is the root span containing same parent and current span IDs" in {
       val testEmitter = new TestEmitter[IO]
@@ -105,7 +106,7 @@ class TestEmitterRecordingTest extends WordSpec with BeforeAndAfterEach with Mat
       } yield ()
       generateSalesFigures.trace(TraceContext(spanRoot, false, salesManagementSystem)).unsafeRunSync
       val entries = testEmitter.cache.all
-      entries shouldBe 'empty
+      entries shouldBe Nil
     }
   }
 

--- a/core/jvm/src/test/scala/com/ccadllc/cedi/dtrace/TypeclassLawTests.scala
+++ b/core/jvm/src/test/scala/com/ccadllc/cedi/dtrace/TypeclassLawTests.scala
@@ -34,10 +34,11 @@ import java.nio.charset.Charset
 
 import org.scalactic.source
 import org.scalacheck._
-import org.scalatest.prop.Checkers
 import org.scalatest.OptionValues._
 import org.scalatest.TryValues._
-import org.scalatest.{ FunSuite, Matchers, Tag }
+import org.scalatest.{ Matchers, Tag }
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.scalacheck.Checkers
 
 import org.typelevel.discipline.Laws
 import org.typelevel.discipline.scalatest.Discipline
@@ -47,7 +48,7 @@ import scala.concurrent.duration._
 import scala.util.Success
 import scala.util.control.NonFatal
 
-class TypeclassLawTests extends FunSuite with Matchers with Checkers with Discipline with TestInstances with TestData {
+class TypeclassLawTests extends AnyFunSuite with Matchers with Checkers with Discipline with TestInstances with TestData {
 
   private implicit def eqTraceIO[A](implicit A: Eq[A], testC: TestContext): Eq[TraceIO[A]] =
     new Eq[TraceIO[A]] {
@@ -159,7 +160,7 @@ class TypeclassLawTests extends FunSuite with Matchers with Checkers with Discip
   testAsync("ContextShift[TraceIO].shift") { testC =>
     implicit val cs = TraceIO.contextShift(testC)
     val f = cs.shift.trace(tc).unsafeToFuture()
-    f.value shouldBe 'empty
+    f.value shouldBe None
     testC.tick()
     f.value shouldBe Some(Success(()))
     ()
@@ -169,11 +170,11 @@ class TypeclassLawTests extends FunSuite with Matchers with Checkers with Discip
     implicit val cs = TraceIO.contextShift(testC)
     val testC2 = TestContext()
     val f = cs.evalOn(testC2)(TraceIO(1)).trace(tc).unsafeToFuture()
-    f.value shouldBe 'empty
+    f.value shouldBe None
     testC.tick()
-    f.value shouldBe 'empty
+    f.value shouldBe None
     testC2.tick()
-    f.value shouldBe 'empty
+    f.value shouldBe None
     testC.tick()
     f.value shouldBe Some(Success(1))
     ()

--- a/http4s/src/test/scala/com/ccadllc/cedi/dtrace/interop/http4s/DTraceHttp4sTest.scala
+++ b/http4s/src/test/scala/com/ccadllc/cedi/dtrace/interop/http4s/DTraceHttp4sTest.scala
@@ -22,10 +22,11 @@ import cats.effect._
 import org.http4s._
 import org.http4s.dsl.io._
 
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.Matchers
 import org.scalatest.EitherValues._
 import org.scalatest.OptionValues._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.wordspec.AnyWordSpec
 
 import scodec.bits.ByteVector
 
@@ -34,7 +35,7 @@ import interop.http4s.server._
 
 import Uri.uri
 
-class DTraceHttp4sTest extends WordSpec with Matchers with GeneratorDrivenPropertyChecks with TraceGenerators with TestData {
+class DTraceHttp4sTest extends AnyWordSpec with Matchers with GeneratorDrivenPropertyChecks with TraceGenerators with TestData {
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 100)
 

--- a/logging/jvm/src/test/scala/com/ccadllc/cedi/dtrace/logging/JsonLogEncodingTest.scala
+++ b/logging/jvm/src/test/scala/com/ccadllc/cedi/dtrace/logging/JsonLogEncodingTest.scala
@@ -23,13 +23,13 @@ import cats.effect.{ IO, Effect }
 import io.circe._
 import io.circe.syntax._
 
-import org.scalacheck.Arbitrary
+import org.scalatest.prop.Generator
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
 import json.encoding._
 
-class JsonLogEncodingTests extends WordSpec with TestSupport {
+class JsonLogEncodingTests extends AnyWordSpec with TestSupport {
 
   // format: OFF
   val calculateQuarterlySalesTraceContextJson = Json.obj(
@@ -52,8 +52,8 @@ class JsonLogEncodingTests extends WordSpec with TestSupport {
   )
   // format: ON
 
-  implicit def arbTrace[F[_]: Effect]: Arbitrary[TraceContext[F]] = Arbitrary(genTraceContext[F])
+  implicit def traceGenerator[F[_]: Effect]: Generator[TraceContext[F]] = genTraceContext[F]
 
-  "Trace" should { encodeArbitraryJson[TraceContext[IO]] }
+  "Trace" should { encodeGeneratedJson[TraceContext[IO]] }
   "Trace" should { encodeSpecificJson(calculateQuarterlySalesTraceContext, calculateQuarterlySalesTraceContextJson) }
 }

--- a/logging/jvm/src/test/scala/com/ccadllc/cedi/dtrace/logging/JsonLogRecordingTest.scala
+++ b/logging/jvm/src/test/scala/com/ccadllc/cedi/dtrace/logging/JsonLogRecordingTest.scala
@@ -18,9 +18,9 @@ package logging
 
 import java.util.UUID
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class JsonLogRecordingTest extends WordSpec with RecordingTestSupport {
+class JsonLogRecordingTest extends AnyWordSpec with RecordingTestSupport {
   override protected def logEmitterId: String = """"span-id""""
   override protected def spanName(name: Span.Name) = s""""span-name":"$name""""
   override protected def spanId(id: Long) = s""""span-id":$id"""

--- a/logging/jvm/src/test/scala/com/ccadllc/cedi/dtrace/logging/TestSupport.scala
+++ b/logging/jvm/src/test/scala/com/ccadllc/cedi/dtrace/logging/TestSupport.scala
@@ -21,16 +21,15 @@ import cats.effect.{ IO, Sync }
 import io.circe._
 import io.circe.syntax._
 
-import org.scalacheck.Arbitrary
-
-import org.scalatest.{ Matchers, Suite, WordSpecLike }
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{ Matchers, Suite }
+import org.scalatest.prop.{ Generator, GeneratorDrivenPropertyChecks }
+import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.language.higherKinds
 
 import shapeless.Lazy
 
-trait TestSupport extends WordSpecLike with Matchers with GeneratorDrivenPropertyChecks with TraceGenerators with TestData {
+trait TestSupport extends AnyWordSpecLike with Matchers with GeneratorDrivenPropertyChecks with TraceGenerators with TestData {
   self: Suite =>
 
   override def testEmitter[F[_]: Sync]: F[TraceSystem.Emitter[F]] = Sync[F].pure(LogEmitter.apply)
@@ -39,10 +38,10 @@ trait TestSupport extends WordSpecLike with Matchers with GeneratorDrivenPropert
   val salesManagementSystem = TraceSystem(testSystemData, testEmitter[IO].unsafeRunSync, TraceSystem.realTimeTimer[IO])
   val calculateQuarterlySalesTraceContext = TraceContext(quarterlySalesCalculationSpan, true, salesManagementSystem)
 
-  def encodeArbitraryJson[A: Arbitrary](implicit encoder: Lazy[Encoder[A]]): Unit = {
+  def encodeGeneratedJson[A: Generator](implicit encoder: Lazy[Encoder[A]]): Unit = {
     implicit val e = encoder.value
     "encode arbitrary instances to JSON" in {
-      forAll { (msg: A) => msg.asJson.noSpaces should not be ('empty) }
+      forAll { (msg: A) => msg.asJson.noSpaces should not be (None) }
     }
   }
   def encodeSpecificJson[A](a: A, json: Json)(implicit encoder: Lazy[Encoder[A]]): Unit = {

--- a/logging/jvm/src/test/scala/com/ccadllc/cedi/dtrace/logging/TextLogRecordingTest.scala
+++ b/logging/jvm/src/test/scala/com/ccadllc/cedi/dtrace/logging/TextLogRecordingTest.scala
@@ -18,9 +18,9 @@ package logging
 
 import java.util.UUID
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class TextLogRecordingTest extends WordSpec with RecordingTestSupport {
+class TextLogRecordingTest extends AnyWordSpec with RecordingTestSupport {
   override protected def logEmitterId: String = "span-id="
   override protected def spanName(name: Span.Name) = s"span-name=$name"
   override protected def spanId(id: Long) = s"span-id=$id"

--- a/logstash/src/test/scala/com/ccadllc/cedi/dtrace/logstash/EcsLogstashLogbackEmitterTest.scala
+++ b/logstash/src/test/scala/com/ccadllc/cedi/dtrace/logstash/EcsLogstashLogbackEmitterTest.scala
@@ -17,9 +17,9 @@ package com.ccadllc.cedi.dtrace
 package logstash
 
 import cats.effect.IO
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class EcsLogstashLogbackEmitterTest extends WordSpec with TestData {
+class EcsLogstashLogbackEmitterTest extends AnyWordSpec with TestData {
   "EcsLogstashLogbackEmitterTest" should {
     "work" in {
       val system = TraceSystem(testSystemData, new EcsLogstashLogbackEmitter[IO], quarterlySalesCalculationTimer)

--- a/logstash/src/test/scala/com/ccadllc/cedi/dtrace/logstash/LogstashLogbackEmitterTest.scala
+++ b/logstash/src/test/scala/com/ccadllc/cedi/dtrace/logstash/LogstashLogbackEmitterTest.scala
@@ -17,9 +17,9 @@ package com.ccadllc.cedi.dtrace
 package logstash
 
 import cats.effect.IO
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class LogstashLogbackEmitterTest extends WordSpec with TestData {
+class LogstashLogbackEmitterTest extends AnyWordSpec with TestData {
   "LogstashLogbackEmitterTest" should {
     "work" in {
       val system = TraceSystem(testSystemData, new LogstashLogbackEmitter[IO], quarterlySalesCalculationTimer)

--- a/money/jvm/src/test/scala/com/ccadllc/cedi/dtrace/interop/money/MoneyHeaderCodecTest.scala
+++ b/money/jvm/src/test/scala/com/ccadllc/cedi/dtrace/interop/money/MoneyHeaderCodecTest.scala
@@ -19,15 +19,15 @@ package money
 
 import java.util.UUID
 
-import org.scalatest.{ Matchers, WordSpec }
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.scalacheck.Arbitrary
+import org.scalatest.Matchers
+import org.scalatest.prop.{ Generator, GeneratorDrivenPropertyChecks }
+import org.scalatest.wordspec.AnyWordSpec
 
 import MoneyHeaderCodec._
 
-class MoneyHeaderCodecTest extends WordSpec with Matchers with GeneratorDrivenPropertyChecks with TraceGenerators {
+class MoneyHeaderCodecTest extends AnyWordSpec with Matchers with GeneratorDrivenPropertyChecks with TraceGenerators {
 
-  implicit val arbitraryUUID: Arbitrary[UUID] = Arbitrary(genUUID)
+  implicit val uuidGenerator: Generator[UUID] = genUUID
 
   "the Money Header Codec" should {
     "decode correctly given any valid UUID for trace-Id and any valid long integers for parent and span ID" in {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
 resolvers += Resolver.sonatypeRepo("public")
 
-addSbtPlugin("com.ccadllc.cedi" %% "build" % "1.1.0")
+addSbtPlugin("com.ccadllc.cedi" %% "build" % "1.2.0-SNAPSHOT")
 
 addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
 
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.3-SNAPSHOT"
+version in ThisBuild := "2.1.0-SNAPSHOT"

--- a/xb3/jvm/src/test/scala/com/ccadllc/cedi/dtrace/interop/xb3/XB3HeaderCodecTest.scala
+++ b/xb3/jvm/src/test/scala/com/ccadllc/cedi/dtrace/interop/xb3/XB3HeaderCodecTest.scala
@@ -19,17 +19,17 @@ package xb3
 
 import java.util.UUID
 
-import org.scalatest.{ Matchers, WordSpec }
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.scalacheck.Arbitrary
+import org.scalatest.Matchers
+import org.scalatest.prop.{ Generator, GeneratorDrivenPropertyChecks }
+import org.scalatest.wordspec.AnyWordSpec
 
 import scodec.bits.ByteVector
 
 import XB3HeaderCodec._
 
-class XB3HeaderCodecTest extends WordSpec with Matchers with GeneratorDrivenPropertyChecks with TraceGenerators {
+class XB3HeaderCodecTest extends AnyWordSpec with Matchers with GeneratorDrivenPropertyChecks with TraceGenerators {
 
-  implicit val arbitraryUUID: Arbitrary[UUID] = Arbitrary(genUUID)
+  implicit val uuidGenerator: Generator[UUID] = genUUID
 
   "the X-B3 Header Codec" should {
     "decode correctly given any valid UUID for trace-Id and any valid long integers for parent and span ID and sampled boolean" in {


### PR DESCRIPTION
Also have a companion cedi-build for this which I'll PR.  I could - but haven't yet - moved many of the tests to shared from jvm now that we're using scalatest 3.2 and can use Async suites (e.g., AsyncFreeSpec) 