### PR TITLE
Update logstash emitters to use timer unit for duration

### DIFF
--- a/logstash/src/main/scala/com/ccadllc/cedi/dtrace/logstash/EcsLogstashLogbackEmitter.scala
+++ b/logstash/src/main/scala/com/ccadllc/cedi/dtrace/logstash/EcsLogstashLogbackEmitter.scala
@@ -69,7 +69,7 @@ final class EcsLogstashLogbackEmitter[F[_]](implicit F: Sync[F]) extends TraceSy
           and[LogstashMarker](append(ecs.field.spanName, s.spanName.value)).
           and[LogstashMarker](append(ecs.field.spanStart, s.startTime.show)).
           and[LogstashMarker](append(ecs.field.spanOutcome, if (s.failure.isEmpty) "success" else "failure")).
-          and[LogstashMarker](append(ecs.field.spanDuration, s.duration.toNanos)).
+          and[LogstashMarker](append(ecs.field.spanDuration, s.duration.toUnit(tc.system.timer.unit))).
           and[LogstashMarker](append(ecs.field.spanFailureDetail, s.failure.map(_.render).orNull)).
           and[LogstashMarker](append(
             ecs.field.spanMetadata,
@@ -77,7 +77,7 @@ final class EcsLogstashLogbackEmitter[F[_]](implicit F: Sync[F]) extends TraceSy
               n => n.name.value -> n.value).collect { case (name, Some(value)) => name -> value.toString }.toMap).asJava))
         tc.system.data.identity.values.foldLeft(m) { case (acc, (k, v)) => acc.and[LogstashMarker](append(k, v)) }
       }
-      logger.debug(marker, "Span {} {} after {} microseconds",
+      logger.debug(marker, s"Span {} {} after {} ${tc.system.timer.unit.toString.toLowerCase}s",
         s.spanName.value,
         if (s.failure.isEmpty) "succeeded" else "failed",
         s.duration.toMicros.toString)

--- a/logstash/src/main/scala/com/ccadllc/cedi/dtrace/logstash/LogstashLogbackEmitter.scala
+++ b/logstash/src/main/scala/com/ccadllc/cedi/dtrace/logstash/LogstashLogbackEmitter.scala
@@ -50,9 +50,9 @@ final class LogstashLogbackEmitter[F[_]](implicit F: Sync[F]) extends TraceSyste
           and[LogstashMarker](append("start-time", s.startTime.show)).
           and[LogstashMarker](append("span-success", s.failure.isEmpty)).
           and[LogstashMarker](append("failure-detail", s.failure.map(_.render).orNull)).
-          and[LogstashMarker](append("span-duration", s.duration.toMicros)).
+          and[LogstashMarker](append("span-duration", s.duration.toUnit(tc.system.timer.unit))).
           and[LogstashMarker](append("notes", s.notes.map(n => n.name.value -> n.value).collect { case (name, Some(value)) => name -> value.toString }.toMap.asJava))
-      logger.debug(marker, "Span {} {} after {} microseconds",
+      logger.debug(marker, s"Span {} {} after {} ${tc.system.timer.unit.toString.toLowerCase}s",
         s.spanName.value,
         if (s.failure.isEmpty) "succeeded" else "failed",
         s.duration.toMicros.toString)


### PR DESCRIPTION
The logstash emitters have the duration hardcoded to nanoseconds when it should be using the unit in the timer of the system component of the trace context.

I'd like to get this in and release a 3.0.1 (ti was meant to be in 3.0.0 but got missed).

cc / @pauljamescleary 