### PR TITLE
Topic/fix extra unit

### DIFF
--- a/logstash/src/main/scala/com/ccadllc/cedi/dtrace/logstash/EcsLogstashLogbackEmitter.scala
+++ b/logstash/src/main/scala/com/ccadllc/cedi/dtrace/logstash/EcsLogstashLogbackEmitter.scala
@@ -76,7 +76,7 @@ final class EcsLogstashLogbackEmitter[F[_]](implicit F: Sync[F]) extends TraceSy
               n => n.name.value -> n.value).collect { case (name, Some(value)) => name -> value.toString }.toMap).asJava))
         tc.system.data.identity.values.foldLeft(m) { case (acc, (k, v)) => acc.and[LogstashMarker](append(k, v)) }
       }
-      logger.debug(marker, s"Span {} {} after {} ${tc.system.timer.unit.toString.toLowerCase}s",
+      logger.debug(marker, s"Span {} {} after {} ${tc.system.timer.unit.toString.toLowerCase}",
         s.spanName.value,
         if (s.failure.isEmpty) "succeeded" else "failed",
         s.duration.toUnit(tc.system.timer.unit).toString)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.0.1"
+version in ThisBuild := "3.0.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.0.2-SNAPSHOT"
+version in ThisBuild := "3.0.1"


### PR DESCRIPTION
minor nit - unit string value itself already includes the plural 's' so we have two 's's now  ...  / cc @pauljamescleary 
